### PR TITLE
fix: update Go version to 1.23 and configure Renovate to prevent pre-release versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.23'
 
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3
@@ -111,7 +111,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.23'
 
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3
@@ -155,7 +155,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.23'
 
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3
@@ -229,7 +229,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.23'
 
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3
@@ -284,7 +284,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.23'
 
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3

--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,18 @@
       "groupName": "terraform providers",
       "datasources": ["terraform-provider"],
       "updateTypes": ["minor", "patch"]
+    },
+    {
+      "matchDatasources": ["golang-version"],
+      "ignoreUnstable": true,
+      "enabled": true
+    },
+    {
+      "matchDepTypes": ["action"],
+      "matchPackageNames": ["actions/setup-go"],
+      "extractVersion": "^v(?<version>.*)$",
+      "versioning": "go-mod-directive",
+      "ignoreUnstable": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Fixed Go version from invalid 1.24 to stable 1.23 in test.yml workflow
- Added Renovate configuration to prevent future pre-release Go version suggestions

## Changes
- Updated `.github/workflows/test.yml` to use Go version 1.23 (was using non-existent 1.24)
- Enhanced `renovate.json` with rules to:
  - Ignore unstable golang-version datasource releases
  - Prevent unstable versions for actions/setup-go action

## Test Plan
- [ ] GitHub Actions tests should now pass with valid Go version
- [ ] Renovate will no longer suggest pre-release Go versions