### PR TITLE
fix: release Terraform refactors as patches

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -4,7 +4,25 @@
       "release-type": "terraform-module",
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": false,
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "changelog-sections": [
+        {
+          "type": "feat",
+          "section": "Features"
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes"
+        },
+        {
+          "type": "perf",
+          "section": "Performance Improvements"
+        },
+        {
+          "type": "refactor",
+          "section": "Code Refactoring"
+        }
+      ]
     }
   },
   "pull-request-title-pattern": "chore: release ${version}"


### PR DESCRIPTION
## Summary
- Configure release-please changelog sections explicitly for Terraform module releases.
- Add `refactor` commits to the generated changelog under **Code Refactoring**.
- Preserve existing `feat`, `fix`, and `perf` release/changelog behavior.

## Policy
Terraform module implementation code is the distributed artifact. Future implementation refactors that affect module behavior, provider compatibility, defaults, validations, locals, or resource construction should use honest `refactor:` commits and release-please will include them in patch release generation instead of requiring maintainers to mislabel them as `fix:`.

Docs-only and CI-only commits remain outside these user-facing changelog sections unless intentionally configured later.

Closes #66

## Validation
- `python3 -m json.tool .release-please-config.json`
- `pnpm dlx ajv-cli validate -s /tmp/release-please-config.schema.json -d .release-please-config.json --strict=false` (`.release-please-config.json valid`)
- `pre-commit run --files .release-please-config.json`
