### PR TITLE
fix: repair CI security workflow wiring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,15 @@ on:
         default: true
         type: boolean
 
+permissions: {}
+
 jobs:
   # Primary validation workflow
   validate:
     name: Validate
     uses: ./.github/workflows/validate.yml
+    permissions:
+      contents: read
 
   # Security scanning workflow
   security:
@@ -39,6 +43,8 @@ jobs:
     name: Quick Tests
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
 
     steps:
     - name: Checkout
@@ -68,6 +74,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_integration_tests == 'true')
     needs: [validate]
+    permissions:
+      contents: read
 
     steps:
     - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,10 @@ jobs:
     name: Security
     uses: ./.github/workflows/security.yml
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.run_security_scans != 'false'
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
 
   # Quick static tests for pull requests
   quick-tests:
@@ -122,8 +126,19 @@ jobs:
         echo "- **Quick Tests**: Fast static tests for pull request validation" >> $GITHUB_STEP_SUMMARY
         echo "- **Integration Tests**: Real AWS ECR Public repository creation and testing" >> $GITHUB_STEP_SUMMARY
 
-        # Check for failures
-        if [[ "${{ needs.validate.result }}" != "success" || "${{ needs.security.result }}" != "success" || "${{ needs.quick-tests.result }}" != "success" || "${{ needs.integration-tests.result }}" != "success" ]]; then
+        # Check for failures. Some jobs are intentionally skipped depending on
+        # the trigger (for example PR-only quick tests or optional integration
+        # tests), so treat success and skipped as acceptable terminal states.
+        validate_result="${{ needs.validate.result }}"
+        security_result="${{ needs.security.result }}"
+        quick_tests_result="${{ needs.quick-tests.result }}"
+        integration_tests_result="${{ needs.integration-tests.result }}"
+
+        is_ok() {
+          [[ "$1" == "success" || "$1" == "skipped" ]]
+        }
+
+        if ! is_ok "$validate_result" || ! is_ok "$security_result" || ! is_ok "$quick_tests_result" || ! is_ok "$integration_tests_result"; then
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "❌ CI pipeline has failures. Please review the failed workflows." >> $GITHUB_STEP_SUMMARY
           exit 1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -36,6 +36,11 @@ jobs:
           exit 0
         fi
 
+        if [[ "${{ github.event_name }}" == "workflow_call" ]]; then
+          echo "skip_security=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
         if [[ "${{ github.event_name }}" == "push" ]] && [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
           echo "skip_security=false" >> $GITHUB_OUTPUT
           exit 0
@@ -411,7 +416,15 @@ jobs:
         echo "- Repository names should follow lowercase conventions" >> $GITHUB_STEP_SUMMARY
         echo "- All repositories must be created in **us-east-1** region" >> $GITHUB_STEP_SUMMARY
 
-        if [[ "${{ needs.security-scan.result }}" != "success" || "${{ needs.security-scan-examples.result }}" != "success" || "${{ needs.public-content-audit.result }}" != "success" ]]; then
+        security_scan_result="${{ needs.security-scan.result }}"
+        security_examples_result="${{ needs.security-scan-examples.result }}"
+        public_content_audit_result="${{ needs.public-content-audit.result }}"
+
+        is_ok() {
+          [[ "$1" == "success" || "$1" == "skipped" ]]
+        }
+
+        if ! is_ok "$security_scan_result" || ! is_ok "$security_examples_result" || ! is_ok "$public_content_audit_result"; then
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "❌ Some security checks failed. Please review the logs and address issues before merging." >> $GITHUB_STEP_SUMMARY
           exit 1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,9 +5,15 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_call:
   schedule:
     - cron: '0 0 * * 1'  # Weekly on Mondays
   workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
 
 jobs:
   # Check if we should skip security scans for documentation-only changes
@@ -169,6 +175,7 @@ jobs:
     - name: Upload checkov results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3
       if: always() && hashFiles('checkov-results.sarif') != ''
+      continue-on-error: true
       with:
         sarif_file: checkov-results.sarif
         category: checkov
@@ -176,6 +183,7 @@ jobs:
     - name: Upload tfsec results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3
       if: always() && hashFiles('tfsec-results.sarif') != ''
+      continue-on-error: true
       with:
         sarif_file: tfsec-results.sarif
         category: tfsec

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,6 +33,13 @@ jobs:
           exit 0
         fi
 
+        if [[ "${{ github.event_name }}" == "workflow_call" ]]; then
+          echo "skip_ci=false" >> $GITHUB_OUTPUT
+          echo "terraform_changed=true" >> $GITHUB_OUTPUT
+          echo "examples_changed=true" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
         if [[ "${{ github.event_name }}" == "push" ]] && [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
           echo "skip_ci=false" >> $GITHUB_OUTPUT
           echo "terraform_changed=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_call:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- Make `validate.yml` and `security.yml` callable from the aggregate `ci.yml` workflow with `workflow_call`.
- Grant the security workflow the permissions needed for SARIF upload and make SARIF upload best-effort so Code Scanning resource/API availability does not fail the whole security job.
- Fix the aggregate CI summary so intentionally skipped jobs are not treated as failures.

Closes #29

## Validation
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/security.yml .github/workflows/validate.yml`
