### PR TITLE
fix: escape catalog data test variables

### DIFF
--- a/test/terraform_catalog_data_test.go
+++ b/test/terraform_catalog_data_test.go
@@ -109,7 +109,7 @@ func TestECRPublicComprehensiveCatalogData(t *testing.T) {
 			"repository_name": repositoryName,
 			"catalog_data": map[string]interface{}{
 				"description": "Enterprise-grade application container with comprehensive tooling and security features",
-				"about_text": `# Enterprise Application Container
+				"about_text": hclVarString(`# Enterprise Application Container
 
 ## Overview
 
@@ -152,13 +152,13 @@ This image supports multiple architectures:
 
 - **NIST Guidelines**: Follows NIST container security guidelines
 - **CIS Benchmarks**: Compliant with CIS security benchmarks
-- **OWASP Standards**: Implements OWASP container security practices`,
+- **OWASP Standards**: Implements OWASP container security practices`),
 				"usage_text": func() string {
 					data, err := loadTestData("comprehensive_catalog_usage.md", repositoryName)
 					if err != nil {
 						t.Fatalf("Failed to load test data: %v", err)
 					}
-					return data
+					return hclVarString(data)
 				}(),
 				"architectures":     []string{"x86-64", "ARM", "ARM 64"},
 				"operating_systems": []string{"Linux"},

--- a/test/terraform_integration_test.go
+++ b/test/terraform_integration_test.go
@@ -227,8 +227,8 @@ func TestTerraformECRPublicCompleteConfiguration(t *testing.T) {
 			"repository_name": repositoryName,
 			"catalog_data": map[string]interface{}{
 				"description":       "Complete test repository",
-				"about_text":       "# Complete Test\nTest repository.",
-				"usage_text":       "# Usage\n```bash\ndocker pull public.ecr.aws/registry/" + repositoryName + ":latest\n```",
+				"about_text":       hclVarString("# Complete Test\nTest repository."),
+				"usage_text":       hclVarString("# Usage\n```bash\ndocker pull public.ecr.aws/registry/" + repositoryName + ":latest\n```"),
 				"architectures":     []string{"x86-64", "ARM", "ARM 64"},
 				"operating_systems": []string{"Linux"},
 			},

--- a/test/terraform_public_gallery_test.go
+++ b/test/terraform_public_gallery_test.go
@@ -35,14 +35,14 @@ func TestECRPublicGalleryOptimization(t *testing.T) {
 					if err != nil {
 						t.Fatalf("Failed to load test data: %v", err)
 					}
-					return data
+					return hclVarString(data)
 				}(),
 				"usage_text": func() string {
 					data, err := loadTestData("gallery_optimization_usage.md", repositoryName)
 					if err != nil {
 						t.Fatalf("Failed to load test data: %v", err)
 					}
-					return data
+					return hclVarString(data)
 				}(),
 				"architectures":     []string{"x86-64", "ARM 64"},
 				"operating_systems": []string{"Linux"},
@@ -128,7 +128,7 @@ func TestECRPublicGalleryContentGuidelines(t *testing.T) {
 			"repository_name": repositoryName,
 			"catalog_data": map[string]interface{}{
 				"description": "Enterprise Java application server with Spring Boot, security hardening, and production monitoring",
-				"about_text": `# Enterprise Java Application Server
+				"about_text": hclVarString(`# Enterprise Java Application Server
 
 ## Overview
 
@@ -174,13 +174,13 @@ This image follows enterprise architecture patterns:
 - **Maven/Gradle**: Build tool support
 - **PostgreSQL/MySQL**: Database connectivity
 - **Redis**: Caching and session management
-- **Kafka**: Event streaming support`,
+- **Kafka**: Event streaming support`),
 				"usage_text":        func() string {
 					data, err := loadTestData("spring_boot_usage.md", repositoryName)
 					if err != nil {
 						t.Fatalf("Failed to load test data: %v", err)
 					}
-					return data
+					return hclVarString(data)
 				}(),
 				"architectures":     []string{"x86-64", "ARM 64"},
 				"operating_systems": []string{"Linux"},

--- a/test/test_helpers.go
+++ b/test/test_helpers.go
@@ -44,10 +44,16 @@ func generateMinimalCatalogData(repositoryName string) map[string]interface{} {
 // hclVarString escapes strings embedded in object-typed Terraform -var values.
 // Terratest renders map variables as HCL object expressions; raw newlines inside
 // object string values make Terraform parse the generated -var argument as an
-// invalid multi-line string. Keeping \n as an HCL escape preserves the intended
-// catalog text while keeping the generated object expression valid.
+// invalid multi-line string. Escaping HCL quoted-string metacharacters preserves
+// the intended catalog text while keeping the generated object expression valid.
 func hclVarString(value string) string {
-	return strings.ReplaceAll(value, "\n", "\\n")
+	value = strings.ReplaceAll(value, "\\", "\\\\")
+	value = strings.ReplaceAll(value, "\"", "\\\"")
+	value = strings.ReplaceAll(value, "\n", "\\n")
+	value = strings.ReplaceAll(value, "\t", "\\t")
+	value = strings.ReplaceAll(value, "${", "$${")
+	value = strings.ReplaceAll(value, "%{", "%%{")
+	return value
 }
 
 // generateMinimalVariableCatalogData creates minimal catalog data using individual variables

--- a/test/test_helpers.go
+++ b/test/test_helpers.go
@@ -34,11 +34,20 @@ func generateMinimalCatalogData(repositoryName string) map[string]interface{} {
 	// Note: repositoryName validation is handled by the calling function via ensureSafeTestExecution
 	return map[string]interface{}{
 		"description": "Test container",
-		"about_text":  "# Test\nBasic test container.",
-		"usage_text":  fmt.Sprintf("# Usage\n```bash\ndocker pull public.ecr.aws/registry/%s:latest\n```", repositoryName),
+		"about_text":  hclVarString("# Test\nBasic test container."),
+		"usage_text":  hclVarString(fmt.Sprintf("# Usage\n```bash\ndocker pull public.ecr.aws/registry/%s:latest\n```", repositoryName)),
 		"architectures": []string{"x86-64"},
 		"operating_systems": []string{"Linux"},
 	}
+}
+
+// hclVarString escapes strings embedded in object-typed Terraform -var values.
+// Terratest renders map variables as HCL object expressions; raw newlines inside
+// object string values make Terraform parse the generated -var argument as an
+// invalid multi-line string. Keeping \n as an HCL escape preserves the intended
+// catalog text while keeping the generated object expression valid.
+func hclVarString(value string) string {
+	return strings.ReplaceAll(value, "\n", "\\n")
 }
 
 // generateMinimalVariableCatalogData creates minimal catalog data using individual variables


### PR DESCRIPTION
## Summary
- escape multiline strings used in object-typed Terratest `catalog_data` variables
- keep variable-based test inputs unchanged
- fixes the main CI integration failure exposed after #69

## Validation
- `pre-commit run --files test/test_helpers.go test/terraform_integration_test.go test/terraform_public_gallery_test.go test/terraform_catalog_data_test.go`
- `git diff --check`

Follow-up to #69 / #29.