### PR TITLE
fix: expose expected outputs in variables example

### DIFF
--- a/examples/using_variables/README.md
+++ b/examples/using_variables/README.md
@@ -52,11 +52,14 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_arn"></a> [arn](#output\_arn) | Full ARN of the repository |
 | <a name="output_catalog_data"></a> [catalog\_data](#output\_catalog\_data) | The catalog data configuration for the repository |
 | <a name="output_gallery_url"></a> [gallery\_url](#output\_gallery\_url) | The URL to the repository in ECR Public Gallery |
+| <a name="output_id"></a> [id](#output\_id) | The registry ID where the repository was created |
 | <a name="output_registry_id"></a> [registry\_id](#output\_registry\_id) | The registry ID where the repository was created |
 | <a name="output_repository_arn"></a> [repository\_arn](#output\_repository\_arn) | Full ARN of the repository |
 | <a name="output_repository_name"></a> [repository\_name](#output\_repository\_name) | Name of the repository |
+| <a name="output_repository_uri"></a> [repository\_uri](#output\_repository\_uri) | The URI of the repository |
 | <a name="output_repository_url"></a> [repository\_url](#output\_repository\_url) | The URL of the repository |
 | <a name="output_tags_all"></a> [tags\_all](#output\_tags\_all) | A map of tags assigned to the resource, including those inherited from the provider default\_tags |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/using_variables/outputs.tf
+++ b/examples/using_variables/outputs.tf
@@ -8,9 +8,24 @@ output "repository_url" {
   value       = module.public-ecr.repository_url
 }
 
+output "arn" {
+  description = "Full ARN of the repository"
+  value       = module.public-ecr.arn
+}
+
 output "repository_arn" {
   description = "Full ARN of the repository"
   value       = module.public-ecr.repository_arn
+}
+
+output "repository_uri" {
+  description = "The URI of the repository"
+  value       = module.public-ecr.repository_uri
+}
+
+output "id" {
+  description = "The registry ID where the repository was created"
+  value       = module.public-ecr.id
 }
 
 output "registry_id" {


### PR DESCRIPTION
## Summary
- add `arn`, `repository_uri`, and `id` outputs to `examples/using_variables`
- update generated example README docs
- fixes the remaining main integration-test failures where shared test helpers expect the same output contract as the root module

## Validation
- `terraform init -backend=false -input=false` in `examples/using_variables`
- `terraform validate` in `examples/using_variables`
- `pre-commit run --files examples/using_variables/outputs.tf examples/using_variables/README.md`
- `git diff --check`

Follow-up to #29.