### PR TITLE
feat: align validation with ECR Public constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ README.md updated successfully
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 2.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2, < 2.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0, < 7.0 |
 
 ## Providers

--- a/README.md
+++ b/README.md
@@ -446,14 +446,14 @@ README.md updated successfully
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 2.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0, < 7.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
 
 ## Modules
 

--- a/variables.tf
+++ b/variables.tf
@@ -4,13 +4,13 @@ variable "repository_name" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$", var.repository_name))
-    error_message = "Repository name must start and end with an alphanumeric character and can only contain lowercase letters, numbers, hyphens, underscores, and periods."
+    condition     = can(regex("^(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*$", var.repository_name))
+    error_message = "Repository name must follow the ECR Public pattern '(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*'."
   }
 
   validation {
-    condition     = length(var.repository_name) >= 2 && length(var.repository_name) <= 256
-    error_message = "Repository name must be between 2 and 256 characters long."
+    condition     = length(var.repository_name) >= 2 && length(var.repository_name) <= 205
+    error_message = "Repository name must be between 2 and 205 characters long."
   }
 
   validation {
@@ -24,6 +24,61 @@ variable "catalog_data" {
   description = "Catalog data configuration for the repository."
   type        = any
   default     = {}
+
+  validation {
+    condition     = can(keys(var.catalog_data))
+    error_message = "Catalog data must be an object/map."
+  }
+
+  validation {
+    condition = can(keys(var.catalog_data)) && alltrue([
+      for key in keys(var.catalog_data) :
+      contains(["about_text", "architectures", "description", "logo_image_blob", "operating_systems", "usage_text"], key)
+    ])
+    error_message = "Catalog data supports only these keys: about_text, architectures, description, logo_image_blob, operating_systems, usage_text."
+  }
+
+  validation {
+    condition     = !can(var.catalog_data.description) || try(var.catalog_data.description == null || length(var.catalog_data.description) <= 1024, false)
+    error_message = "Catalog data description must be 1024 characters or less."
+  }
+
+  validation {
+    condition     = !can(var.catalog_data.about_text) || try(var.catalog_data.about_text == null || length(var.catalog_data.about_text) <= 25600, false)
+    error_message = "Catalog data about_text must be 25600 characters or less."
+  }
+
+  validation {
+    condition     = !can(var.catalog_data.usage_text) || try(var.catalog_data.usage_text == null || length(var.catalog_data.usage_text) <= 25600, false)
+    error_message = "Catalog data usage_text must be 25600 characters or less."
+  }
+
+  validation {
+    condition     = !can(var.catalog_data.logo_image_blob) || try(var.catalog_data.logo_image_blob == null || (can(base64decode(var.catalog_data.logo_image_blob)) && length(var.catalog_data.logo_image_blob) <= 512000), false)
+    error_message = "Catalog data logo_image_blob must be valid base64 and 512000 characters or less."
+  }
+
+  validation {
+    condition = !can(var.catalog_data.architectures) || try(var.catalog_data.architectures == null || (
+      length(var.catalog_data.architectures) <= 50 &&
+      alltrue([
+        for arch in var.catalog_data.architectures :
+        contains(["ARM", "ARM 64", "x86", "x86-64"], arch) && length(arch) >= 1 && length(arch) <= 50
+      ])
+    ), false)
+    error_message = "Catalog data architectures must contain at most 50 supported values: ARM, ARM 64, x86, x86-64."
+  }
+
+  validation {
+    condition = !can(var.catalog_data.operating_systems) || try(var.catalog_data.operating_systems == null || (
+      length(var.catalog_data.operating_systems) <= 50 &&
+      alltrue([
+        for os in var.catalog_data.operating_systems :
+        contains(["Linux", "Windows"], os) && length(os) >= 1 && length(os) <= 50
+      ])
+    ), false)
+    error_message = "Catalog data operating_systems must contain at most 50 supported values: Linux, Windows."
+  }
 }
 
 variable "catalog_data_about_text" {
@@ -37,8 +92,8 @@ variable "catalog_data_about_text" {
   }
 
   validation {
-    condition     = var.catalog_data_about_text == null || try(length(var.catalog_data_about_text) <= 16384, true)
-    error_message = "About text must be 16384 characters or less for ECR Public Gallery."
+    condition     = var.catalog_data_about_text == null || try(length(var.catalog_data_about_text) <= 25600, true)
+    error_message = "About text must be 25600 characters or less for ECR Public Gallery."
   }
 
   validation {
@@ -53,11 +108,11 @@ variable "catalog_data_architectures" {
   default     = []
 
   validation {
-    condition = length(var.catalog_data_architectures) == 0 || alltrue([
+    condition = length(var.catalog_data_architectures) <= 50 && (length(var.catalog_data_architectures) == 0 || alltrue([
       for arch in var.catalog_data_architectures :
-      contains(["ARM", "ARM 64", "x86", "x86-64"], arch)
-    ])
-    error_message = "Architectures must be one of: ARM, ARM 64, x86, x86-64."
+      contains(["ARM", "ARM 64", "x86", "x86-64"], arch) && length(arch) >= 1 && length(arch) <= 50
+    ]))
+    error_message = "Architectures must contain at most 50 supported values: ARM, ARM 64, x86, x86-64."
   }
 }
 
@@ -67,8 +122,8 @@ variable "catalog_data_description" {
   default     = null
 
   validation {
-    condition     = var.catalog_data_description == null || try(length(var.catalog_data_description) <= 256, true)
-    error_message = "Description must be 256 characters or less for ECR Public Gallery visibility."
+    condition     = var.catalog_data_description == null || try(length(var.catalog_data_description) <= 1024, true)
+    error_message = "Description must be 1024 characters or less for ECR Public Gallery visibility."
   }
 
   validation {
@@ -88,8 +143,8 @@ variable "catalog_data_logo_image_blob" {
   }
 
   validation {
-    condition     = var.catalog_data_logo_image_blob == null || try(length(var.catalog_data_logo_image_blob) <= 2097152, true)
-    error_message = "Logo image must be under 2MB when base64-encoded to prevent resource exhaustion."
+    condition     = var.catalog_data_logo_image_blob == null || try(length(var.catalog_data_logo_image_blob) <= 512000, true)
+    error_message = "Logo image must be 512000 characters or less when base64-encoded."
   }
 }
 
@@ -99,11 +154,11 @@ variable "catalog_data_operating_systems" {
   default     = []
 
   validation {
-    condition = length(var.catalog_data_operating_systems) == 0 || alltrue([
+    condition = length(var.catalog_data_operating_systems) <= 50 && (length(var.catalog_data_operating_systems) == 0 || alltrue([
       for os in var.catalog_data_operating_systems :
-      contains(["Linux", "Windows"], os)
-    ])
-    error_message = "Operating systems must be one of: Linux, Windows."
+      contains(["Linux", "Windows"], os) && length(os) >= 1 && length(os) <= 50
+    ]))
+    error_message = "Operating systems must contain at most 50 supported values: Linux, Windows."
   }
 }
 
@@ -118,8 +173,8 @@ variable "catalog_data_usage_text" {
   }
 
   validation {
-    condition     = var.catalog_data_usage_text == null || try(length(var.catalog_data_usage_text) <= 10240, true)
-    error_message = "Usage text must be 10240 characters or less for ECR Public Gallery."
+    condition     = var.catalog_data_usage_text == null || try(length(var.catalog_data_usage_text) <= 25600, true)
+    error_message = "Usage text must be 25600 characters or less for ECR Public Gallery."
   }
 
   validation {
@@ -183,4 +238,17 @@ variable "tags" {
   description = "A map of tags to assign to the resource."
   type        = map(string)
   default     = {}
+
+  validation {
+    condition     = length(var.tags) <= 200
+    error_message = "At most 200 tags can be assigned to an ECR Public repository."
+  }
+
+  validation {
+    condition = alltrue([
+      for key, value in var.tags :
+      length(key) >= 1 && length(key) <= 128 && length(value) <= 256
+    ])
+    error_message = "Tag keys must be 1-128 characters and tag values must be 256 characters or less."
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@ variable "repository_name" {
 
   validation {
     condition     = can(regex("^(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*$", var.repository_name))
-    error_message = "Repository name must follow the ECR Public pattern '(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*'."
+    error_message = "Repository name must use lowercase letters and numbers, may include separators '.', '_', '-', and '/', and each path segment must start and end with an alphanumeric character."
   }
 
   validation {
@@ -24,11 +24,6 @@ variable "catalog_data" {
   description = "Catalog data configuration for the repository."
   type        = any
   default     = {}
-
-  validation {
-    condition     = can(keys(var.catalog_data))
-    error_message = "Catalog data must be an object/map."
-  }
 
   validation {
     condition = can(keys(var.catalog_data)) && alltrue([
@@ -63,7 +58,7 @@ variable "catalog_data" {
       length(var.catalog_data.architectures) <= 50 &&
       alltrue([
         for arch in var.catalog_data.architectures :
-        contains(["ARM", "ARM 64", "x86", "x86-64"], arch) && length(arch) >= 1 && length(arch) <= 50
+        contains(["ARM", "ARM 64", "x86", "x86-64"], arch)
       ])
     ), false)
     error_message = "Catalog data architectures must contain at most 50 supported values: ARM, ARM 64, x86, x86-64."
@@ -74,7 +69,7 @@ variable "catalog_data" {
       length(var.catalog_data.operating_systems) <= 50 &&
       alltrue([
         for os in var.catalog_data.operating_systems :
-        contains(["Linux", "Windows"], os) && length(os) >= 1 && length(os) <= 50
+        contains(["Linux", "Windows"], os)
       ])
     ), false)
     error_message = "Catalog data operating_systems must contain at most 50 supported values: Linux, Windows."
@@ -110,7 +105,7 @@ variable "catalog_data_architectures" {
   validation {
     condition = length(var.catalog_data_architectures) <= 50 && (length(var.catalog_data_architectures) == 0 || alltrue([
       for arch in var.catalog_data_architectures :
-      contains(["ARM", "ARM 64", "x86", "x86-64"], arch) && length(arch) >= 1 && length(arch) <= 50
+      contains(["ARM", "ARM 64", "x86", "x86-64"], arch)
     ]))
     error_message = "Architectures must contain at most 50 supported values: ARM, ARM 64, x86, x86-64."
   }
@@ -156,7 +151,7 @@ variable "catalog_data_operating_systems" {
   validation {
     condition = length(var.catalog_data_operating_systems) <= 50 && (length(var.catalog_data_operating_systems) == 0 || alltrue([
       for os in var.catalog_data_operating_systems :
-      contains(["Linux", "Windows"], os) && length(os) >= 1 && length(os) <= 50
+      contains(["Linux", "Windows"], os)
     ]))
     error_message = "Operating systems must contain at most 50 supported values: Linux, Windows."
   }

--- a/variables.tf
+++ b/variables.tf
@@ -54,8 +54,8 @@ variable "catalog_data" {
   }
 
   validation {
-    condition     = !can(var.catalog_data.logo_image_blob) || try(var.catalog_data.logo_image_blob == null || (can(base64decode(var.catalog_data.logo_image_blob)) && length(var.catalog_data.logo_image_blob) <= 512000), false)
-    error_message = "Catalog data logo_image_blob must be valid base64 and 512000 characters or less."
+    condition     = !can(var.catalog_data.logo_image_blob) || try(var.catalog_data.logo_image_blob == null || (can(regex("^[A-Za-z0-9+/]*={0,2}$", var.catalog_data.logo_image_blob)) && length(var.catalog_data.logo_image_blob) <= 682668), false)
+    error_message = "Catalog data logo_image_blob must be base64-encoded and represent at most 512000 bytes."
   }
 
   validation {
@@ -138,13 +138,13 @@ variable "catalog_data_logo_image_blob" {
   default     = null
 
   validation {
-    condition     = var.catalog_data_logo_image_blob == null || can(base64decode(var.catalog_data_logo_image_blob))
-    error_message = "Logo image blob must be valid base64-encoded data."
+    condition     = var.catalog_data_logo_image_blob == null || can(regex("^[A-Za-z0-9+/]*={0,2}$", var.catalog_data_logo_image_blob))
+    error_message = "Logo image blob must be base64-encoded data."
   }
 
   validation {
-    condition     = var.catalog_data_logo_image_blob == null || try(length(var.catalog_data_logo_image_blob) <= 512000, true)
-    error_message = "Logo image must be 512000 characters or less when base64-encoded."
+    condition     = var.catalog_data_logo_image_blob == null || try(length(var.catalog_data_logo_image_blob) <= 682668, true)
+    error_message = "Logo image must represent at most 512000 bytes when base64-encoded."
   }
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,11 +1,11 @@
 # Terraform and provider version constraints for ECR Public module
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3, < 2.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 5.0, < 7.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,6 +1,6 @@
 # Terraform and provider version constraints for ECR Public module
 terraform {
-  required_version = ">= 1.3, < 2.0"
+  required_version = ">= 1.2, < 2.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## Summary
- tighten Terraform and AWS provider version constraints (`>= 1.3, < 2.0` and `>= 5.0, < 7.0`)
- align repository name, catalog data, logo, architecture, OS, and tag validation with current AWS ECR Public API constraints
- validate object-based `catalog_data` keys and limits in addition to the per-variable inputs
- update generated Terraform docs

## Sources
- AWS CLI/API docs for `ecr-public create-repository` and `put-repository-catalog-data` constraints
- Terraform Registry provider metadata: hashicorp/aws latest 6.53.0

## Validation
- `terraform init -backend=false -input=false`
- `terraform validate`
- `pre-commit run --files variables.tf versions.tf README.md`
- `git diff --check`
- negative validation checks for invalid repository name and unsupported `catalog_data` key

Closes #3.