### PR TITLE
docs: standardize Terraform Registry structure

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,15 +28,27 @@ repos:
         name: Terraform validate
         description: Validates all Terraform configuration files
 
-      - id: terraform_docs
-        name: Terraform docs
-        description: Inserts input and output documentation into README.md using .terraform-docs.yml
-
       - id: terraform_tflint
         name: Terraform lint
         description: Validates all Terraform configuration files with TFLint
         args:
           - --args=--only=terraform_deprecated_lookup
+
+  # Terraform documentation generation for the root module and examples
+  - repo: local
+    hooks:
+      - id: terraform_docs
+        name: Terraform docs
+        description: Updates Terraform docs in the root README and example READMEs
+        language: system
+        pass_filenames: false
+        files: \.tf$
+        entry: >-
+          bash -c 'set -euo pipefail;
+          terraform-docs --config .terraform-docs.yml .;
+          for d in examples/using_objects examples/using_variables examples/with_repository_policy examples/with_auth_token examples/multiple_repositories; do
+            terraform-docs --config .terraform-docs.yml "$d";
+          done'
 
   # Additional quality checks
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,11 +30,7 @@ repos:
 
       - id: terraform_docs
         name: Terraform docs
-        description: Inserts input and output documentation into README.md
-        args:
-          - --hook-config=--path-to-file=README.md
-          - --hook-config=--add-to-existing-file=true
-          - --hook-config=--create-file-if-not-exist=true
+        description: Inserts input and output documentation into README.md using .terraform-docs.yml
 
       - id: terraform_tflint
         name: Terraform lint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -459,7 +459,7 @@ module "public-ecr" {
 
 ```hcl
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.2, < 2.0"
 
   required_providers {
     aws = {

--- a/README.md
+++ b/README.md
@@ -1,443 +1,128 @@
 ![Terraform](https://lgallardo.com/images/terraform.jpg)
 # terraform-aws-ecrpublic
-Terraform module to create a Public [AWS ECR](https://aws.amazon.com/ecr) to share images in the [ECR Public Gallery](https://gallery.ecr.aws).
 
-## Usage
-You can use this module to create a public ECR registry using objects definition, or using the variables approach:
+Terraform module to create and manage public [Amazon ECR Public](https://aws.amazon.com/ecr/) repositories for sharing container images in the [ECR Public Gallery](https://gallery.ecr.aws/).
 
-Check the [examples](examples/) for the **using objects**, **using variables**, and **multiple repositories** snippets.
+## Terraform Registry compatibility
 
-### Using Objects example
-This example creates an public ECR registry:
+This repository follows Terraform Registry module expectations:
 
-```
+- The GitHub repository is named `terraform-aws-ecrpublic` using the `terraform-<PROVIDER>-<NAME>` pattern.
+- Root module files live at the repository root: `main.tf`, `variables.tf`, `outputs.tf`, and `versions.tf`.
+- Reusable examples live under [`examples/`](examples/) and their documentation shows copy/paste usage with the public registry source address `lgallard/ecrpublic/aws`.
+- Inputs and outputs are generated with `terraform-docs` in this README and in example READMEs.
+- This repository uses Release Please to publish semantic version tags.
+
+ECR Public repositories and authorization tokens are managed through `us-east-1`; configure the AWS provider for `us-east-1` when using this module.
+
+## Complete example
+
+The [`examples/using_variables`](examples/using_variables/) directory is the complete minimal example for Terraform Registry users. Its live Terraform files use `source = "../.."` so local validation and CI test the checked-out module. The copy/paste snippet below uses the public Registry source address.
+
+```hcl
+provider "aws" {
+  region = "us-east-1"
+}
+
 module "public-ecr" {
+  source = "lgallard/ecrpublic/aws"
 
+  repository_name = "my-public-repo"
+
+  catalog_data_description       = "Public container image"
+  catalog_data_about_text        = "# My Public Repository\n\nContainer image published to ECR Public."
+  catalog_data_usage_text        = "# Usage\n\ndocker pull public.ecr.aws/my-registry/my-public-repo:latest"
+  catalog_data_architectures     = ["x86-64"]
+  catalog_data_operating_systems = ["Linux"]
+}
+```
+
+## Examples
+
+| Example | Purpose |
+|---|---|
+| [`using_variables`](examples/using_variables/) | Complete minimal example using individual catalog-data variables. |
+| [`using_objects`](examples/using_objects/) | Configure catalog data through the `catalog_data` object. |
+| [`with_repository_policy`](examples/with_repository_policy/) | Attach an ECR Public repository policy for push access. |
+| [`with_auth_token`](examples/with_auth_token/) | Retrieve an ECR Public authorization token for Docker login and push workflows. |
+| [`multiple_repositories`](examples/multiple_repositories/) | Create multiple repositories with module-level `for_each`. |
+
+## Basic usage
+
+### Object-based catalog data
+
+```hcl
+provider "aws" {
+  region = "us-east-1"
+}
+
+module "public-ecr" {
   source = "lgallard/ecrpublic/aws"
 
   repository_name = "lgallard-public-repo"
 
   catalog_data = {
     about_text        = "# Public repo\nPut your description here using Markdown format"
-    architectures     = ["ARM", "x86-64"]
+    architectures     = ["x86-64"]
     description       = "Description"
-    logo_image_blob   = filebase64("image.png")
     operating_systems = ["Linux"]
-    usage_text        = "# Usage\n How to use you image goes here. Use Markdown format"
+    usage_text        = "# Usage\nHow to use your image goes here. Use Markdown format."
   }
 }
 ```
 
-### Using variables
-This example creates an public ECR registry using variables
+### Variable-based catalog data
 
-```
+```hcl
+provider "aws" {
+  region = "us-east-1"
+}
+
 module "public-ecr" {
-
   source = "lgallard/ecrpublic/aws"
 
   repository_name = "lgallard-public-repo"
 
   catalog_data_about_text        = "# Public repo\nPut your description here using Markdown format"
-  catalog_data_architectures     = ["ARM", "x86-64"]
+  catalog_data_architectures     = ["x86-64"]
   catalog_data_description       = "Description"
-  catalog_data_logo_image_blob   = filebase64("image.png")
   catalog_data_operating_systems = ["Linux"]
-  catalog_data_usage_text        = "# Usage\n How to use you image goes here. Use Markdown format"
-
-}
-
-```
-
-### Multiple Repositories
-
-You can create multiple ECR Public repositories using Terraform's native `for_each` capability at the module level:
-
-```hcl
-locals {
-  repositories = {
-    "frontend" = {
-      description       = "Frontend application container"
-      architectures     = ["x86-64", "ARM 64"]
-      operating_systems = ["Linux"]
-    }
-    "backend" = {
-      description       = "Backend API container"
-      architectures     = ["x86-64"]
-      operating_systems = ["Linux"]
-    }
-    "worker" = {
-      description       = "Background worker container"
-      architectures     = ["x86-64"]
-      operating_systems = ["Linux"]
-    }
-  }
-}
-
-module "public-ecr" {
-  source   = "lgallard/ecrpublic/aws"
-  for_each = local.repositories
-
-  repository_name                = each.key
-  catalog_data_description       = each.value.description
-  catalog_data_architectures     = each.value.architectures
-  catalog_data_operating_systems = each.value.operating_systems
-
-  # Shared configuration
-  catalog_data_about_text = "# ${title(each.key)} Application\n\nContainer image for the ${each.key} component."
-
-  tags = {
-    Environment = "production"
-    Service     = each.key
-    ManagedBy   = "terraform"
-  }
-}
-
-# Access individual repository outputs
-output "frontend_repository_uri" {
-  value = module.public-ecr["frontend"].repository_uri
+  catalog_data_usage_text        = "# Usage\nHow to use your image goes here. Use Markdown format."
 }
 ```
 
-For comprehensive examples and patterns, see [examples/multiple_repositories](examples/multiple_repositories/).
+## Authorization tokens for image push
 
-## Authorization Tokens for Image Push
+ECR Public repositories require authentication tokens for programmatic operations like pushing container images. The `aws_ecrpublic_authorization_token` data source provides credentials for CI/CD integration.
 
-ECR Public repositories require authentication tokens for programmatic operations like pushing container images. The `aws_ecrpublic_authorization_token` data source provides the necessary credentials for CI/CD integration.
+Important notes:
 
-### Important Notes
-
-- **Regional Constraint**: Authorization tokens must be retrieved from `us-east-1` region (same as ECR Public repositories)
-- **Token Expiration**: Authorization tokens expire after 12 hours and should be refreshed for long-running processes
-- **CI/CD Integration**: Essential for automated image pushing in GitHub Actions, Jenkins, and other CI/CD systems
-
-### Using Authorization Tokens
-
-```hcl
-# Authorization token for ECR Public authentication
-data "aws_ecrpublic_authorization_token" "token" {}
-
-module "public-ecr" {
-  source = "lgallard/ecrpublic/aws"
-
-  repository_name = "my-application"
-
-  catalog_data = {
-    description       = "My application container"
-    architectures     = ["x86-64"]
-    operating_systems = ["Linux"]
-  }
-}
-
-# Outputs for CI/CD integration
-output "repository_uri" {
-  value = module.public-ecr.repository_uri
-}
-
-output "authorization_token" {
-  value     = data.aws_ecrpublic_authorization_token.token.authorization_token
-  sensitive = true
-}
-```
-
-### Docker Authentication Commands
+- Authorization tokens must be retrieved from `us-east-1`.
+- Authorization tokens expire after 12 hours.
+- See [`examples/with_auth_token`](examples/with_auth_token/) for a complete token example.
 
 ```bash
-# Method 1: Using AWS CLI (Recommended)
 aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
-
-# Method 2: Using Terraform output
-echo "$AUTHORIZATION_TOKEN" | docker login --username AWS --password-stdin public.ecr.aws
-
-# Push your image
-docker tag my-app:latest <repository_uri>:latest
-docker push <repository_uri>:latest
 ```
-
-### GitHub Actions Integration
-
-```yaml
-name: Push to ECR Public
-on:
-  push:
-    branches: [main]
-
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-
-      - name: Login to ECR Public
-        run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
-
-      - name: Build and push
-        run: |
-          docker build -t ${{ secrets.ECR_REPOSITORY_URI }}:latest .
-          docker push ${{ secrets.ECR_REPOSITORY_URI }}:latest
-```
-
-For a complete example with authorization token integration, see [examples/with_auth_token](examples/with_auth_token/).
 
 ## Testing
 
-This module includes comprehensive automated testing using [Terratest](https://github.com/gruntwork-io/terratest) with specialized ECR Public testing patterns following CLAUDE.md guidelines.
+This module includes static Terraform checks and Go/Terratest integration tests.
 
 ### Prerequisites
 
-- **Terraform** >= 1.0
-- **Go** >= 1.21
-- **AWS credentials** with ECR Public permissions
-- **AWS Region**: Tests must run in `us-east-1` (ECR Public constraint)
+- **Terraform** >= 1.2, < 2.0
+- **Go** >= 1.21 for Go/Terratest suites
+- **AWS credentials** with ECR Public permissions for integration tests
+- **AWS Region**: use `us-east-1` for ECR Public operations
 
-### Quick Start
+### Quick start
 
 ```bash
-# Run static tests only (no AWS resources)
-make test
-
-# Run basic integration tests (creates AWS resources)
-make test-integration
-
-# Run all comprehensive tests
-make test-all
+make test              # Static checks only, no AWS resources
+make test-integration  # Integration tests that create AWS resources
+make test-all          # Full local test suite
 ```
-
-### Available Test Suites
-
-#### Static Tests (No AWS Resources)
-```bash
-make test-static          # Format and validation checks
-make fmt-check           # Terraform formatting validation
-make validate            # Configuration validation
-```
-
-#### Integration Tests (Creates AWS Resources)
-```bash
-make test-integration    # Basic ECR Public repository tests
-make test-catalog        # Catalog data validation tests
-make test-gallery        # Public gallery compliance tests
-make test-timeouts       # Timeout configuration tests
-make test-validation     # Variable validation tests
-```
-
-#### Comprehensive Testing
-```bash
-make check              # All static checks
-make check-all          # All checks including integration tests
-make test-all           # Complete integration test suite
-```
-
-### Test Coverage
-
-#### 1. Static Tests (`terraform_basic_test.go`)
-- **Format validation**: Terraform file formatting
-- **Configuration validation**: Syntax and structure validation
-- **Example validation**: Both `using_objects` and `using_variables` examples
-- **Fast execution**: Completes in seconds, no AWS resources
-
-#### 2. Integration Tests (`terraform_integration_test.go`)
-- **Basic repository creation**: Core ECR Public functionality
-- **Variable-based catalog data**: Individual variable approach testing
-- **Object-based catalog data**: Object configuration approach testing
-- **Timeout configuration**: Custom timeout settings validation
-- **Complete configuration**: Comprehensive feature testing
-
-#### 3. Catalog Data Tests (`terraform_catalog_data_test.go`)
-- **Content validation**: ECR Public Gallery guidelines compliance
-- **Minimal configuration**: Tests minimal valid catalog data
-- **Comprehensive configuration**: Tests all catalog data fields
-- **Multi-architecture support**: Architecture and OS tagging validation
-- **Markdown formatting**: Rich markdown content validation
-
-#### 4. Public Gallery Tests (`terraform_public_gallery_test.go`)
-- **Gallery optimization**: Discoverability and searchability features
-- **Content guidelines**: ECR Public Gallery content standards
-- **Regional constraints**: us-east-1 region requirement validation
-- **Public accessibility**: Global public access validation
-
-### ECR Public Specific Testing
-
-This module follows ECR Public-specific testing patterns:
-
-#### Regional Constraints
-All tests enforce ECR Public's `us-east-1` regional constraint:
-```go
-awsRegion := "us-east-1"
-EnvVars: map[string]string{
-    "AWS_DEFAULT_REGION": awsRegion,
-}
-```
-
-#### Catalog Data Validation
-Tests validate ECR Public Gallery content guidelines:
-- **Description length**: Maximum 256 characters
-- **Architecture validation**: `x86-64`, `ARM`, `ARM 64`
-- **Operating system validation**: `Linux`, `Windows`
-- **Markdown formatting**: Proper markdown in about and usage text
-- **Public content standards**: Appropriate content for public repositories
-
-#### Repository Naming
-Tests use unique repository names to avoid conflicts:
-```go
-uniqueID := strings.ToLower(random.UniqueId())
-repositoryName := fmt.Sprintf("terratest-prefix-%s", uniqueID)
-```
-
-### Test Validation Patterns
-
-The test suite includes specialized validation helpers:
-
-#### Repository Validation
-- `validateECRPublicRepository()`: Basic repository creation validation
-- `validateBasicOutputs()`: Module outputs validation
-- `validateCatalogDataOutputs()`: Catalog data specific validation
-- `validateAllOutputs()`: Comprehensive output validation
-
-#### Gallery Validation
-- `validatePublicGalleryOptimization()`: Gallery discoverability checks
-- `validatePublicGallerySearchability()`: Search optimization validation
-- `validatePublicGalleryContentGuidelines()`: Content compliance validation
-- `validateRegionalConstraints()`: Regional constraint validation
-
-### Example Test Execution
-
-#### Basic Repository Test
-```bash
-cd test
-go test -v -run TestTerraformECRPublicBasic -timeout 30m
-```
-
-#### Catalog Data Validation
-```bash
-cd test
-go test -v -run TestECRPublicCatalogDataValidation -timeout 45m
-```
-
-#### Complete Test Suite
-```bash
-cd test
-go test -v -timeout 30m -parallel 2
-```
-
-### AWS Resources and Costs
-
-⚠️ **Important**: Integration tests create real AWS resources:
-
-- **ECR Public Repositories**: Created and configured with catalog data
-- **Region Requirement**: All resources created in `us-east-1` only
-- **Cost**: ECR Public repositories are free to create and maintain
-- **Cleanup**: Automatic cleanup with `terraform destroy` after each test
-
-### Required AWS Permissions
-
-```json
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ecr-public:CreateRepository",
-                "ecr-public:DeleteRepository",
-                "ecr-public:DescribeRepositories",
-                "ecr-public:GetRepositoryCatalogData",
-                "ecr-public:PutRepositoryCatalogData"
-            ],
-            "Resource": "*"
-        }
-    ]
-}
-```
-
-### Continuous Integration
-
-GitHub Actions workflow provides automated testing:
-
-- **Static Tests**: Run on all pull requests (no AWS resources)
-- **Integration Tests**: Run on main branch or manual dispatch
-- **Parallel Execution**: Optimized for faster feedback
-- **Comprehensive Coverage**: All test suites included
-
-### Troubleshooting
-
-#### Common Issues
-
-**Region Errors**
-```
-Error: ECR Public repositories can only be created in us-east-1
-Solution: Set AWS_DEFAULT_REGION=us-east-1
-```
-
-**Permission Errors**
-```
-Error: Access denied for ECR Public operations
-Solution: Verify AWS credentials have ECR Public permissions
-```
-
-**Repository Conflicts**
-```
-Error: Repository already exists
-Solution: Tests use unique IDs, manual cleanup may be needed
-```
-
-For detailed testing instructions and troubleshooting, see [test/README.md](test/README.md).
-
-## Requirements
-
-No requirements.
-
-## Providers
-
-| Name | Version |
-|------|---------|
-| aws | n/a |
-
-## Modules
-
-No Modules.
-
-## Resources
-
-| Name |
-|------|
-| [aws_ecrpublic_repository](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecrpublic_repository) |
-
-## Inputs
-
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| catalog\_data | Catalog data configuration for the repository. | `any` | `{}` | no |
-| catalog\_data\_about\_text | A detailed description of the contents of the repository. It is publicly visible in the Amazon ECR Public Gallery. The text must be in markdown format. | `string` | `null` | no |
-| catalog\_data\_architectures | The system architecture that the images in the repository are compatible with. On the Amazon ECR Public Gallery, the following supported architectures will appear as badges on the repository and are used as search filters: `Linux`, `Windows`. | `list(string)` | `[]` | no |
-| catalog\_data\_description | A short description of the contents of the repository. This text appears in both the image details and also when searching for repositories on the Amazon ECR Public Gallery. | `string` | `null` | no |
-| catalog\_data\_logo\_image\_blob | The base64-encoded repository logo payload. (Only visible for verified accounts) Note that drift detection is disabled for this attribute. | `string` | `null` | no |
-| catalog\_data\_operating\_systems | The operating systems that the images in the repository are compatible with. On the Amazon ECR Public Gallery, the following supported operating systems will appear as badges on the repository and are used as search filters. 'ARM', 'ARM 64', 'x86', 'x86-64'. | `list(string)` | `null` | no |
-| catalog\_data\_usage\_text | Detailed information on how to use the contents of the repository. It is publicly visible in the Amazon ECR Public Gallery. The usage text provides context, support information, and additional usage details for users of the repository. The text must be in markdown format. | `string` | `null` | no |
-| repository\_name | Name of the repository. | `string` | n/a | yes |
-| timeouts | Timeouts map. | `map` | `{}` | no |
-| timeouts\_delete | How long to wait for a repository to be deleted. | `string` | `null` | no |
-
-## Outputs
-
-| Name | Description |
-|------|-------------|
-| arn | Full ARN of the repository |
-| id | The repository name. |
-| registry\_id | The registry ID where the repository was created. |
-| repository\_uri | The URI of the repository. |
-
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-README.md updated successfully
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 <!-- BEGIN_TF_DOCS -->
 

--- a/examples/multiple_repositories/README.md
+++ b/examples/multiple_repositories/README.md
@@ -1,38 +1,31 @@
-# Multiple Repositories Example
+# Multiple repositories example
 
-This example demonstrates how to create multiple ECR Public repositories using the module's native `for_each` support pattern.
+This example creates multiple ECR Public repositories using Terraform's native `for_each` support at the module call site.
 
-## Overview
+## Copy/paste usage
 
-The terraform-aws-ecrpublic module is designed following Terraform best practices for single-resource management. To create multiple repositories, you can leverage Terraform's native `for_each` meta-argument at the module level.
-
-## Benefits
-
-- **Clean and maintainable**: Uses standard Terraform patterns
-- **Flexible configuration**: Each repository can have unique settings
-- **Shared configuration**: Common settings can be defined once
-- **Backward compatible**: No changes to the existing module interface
-
-## Usage
-
-### Basic Multiple Repositories
+Use this Registry source address in consumer configurations:
 
 ```hcl
+provider "aws" {
+  region = "us-east-1"
+}
+
 locals {
   repositories = {
-    "frontend" = {
-      description = "Frontend application container"
-      architectures = ["x86-64", "ARM 64"]
+    frontend = {
+      description       = "Frontend application container image"
+      architectures     = ["x86-64", "ARM 64"]
       operating_systems = ["Linux"]
     }
-    "backend" = {
-      description = "Backend API container"
-      architectures = ["x86-64"]
+    "api-server" = {
+      description       = "REST API server container image"
+      architectures     = ["x86-64"]
       operating_systems = ["Linux"]
     }
-    "worker" = {
-      description = "Background worker container"
-      architectures = ["x86-64"]
+    worker = {
+      description       = "Background worker container image"
+      architectures     = ["x86-64"]
       operating_systems = ["Linux"]
     }
   }
@@ -42,242 +35,31 @@ module "public-ecr" {
   source   = "lgallard/ecrpublic/aws"
   for_each = local.repositories
 
-  repository_name                = each.key
+  repository_name = each.key
+
   catalog_data_description       = each.value.description
   catalog_data_architectures     = each.value.architectures
   catalog_data_operating_systems = each.value.operating_systems
-
-  # Shared configuration
-  catalog_data_about_text = "# ${title(each.key)} Application\n\nContainer image for the ${each.key} component of our microservices architecture."
-  catalog_data_usage_text = "# Usage\n\n```bash\ndocker pull public.ecr.aws/${var.registry_alias}/${each.key}:latest\n```"
-
-  tags = {
-    Environment = "production"
-    Service     = each.key
-    ManagedBy   = "terraform"
-  }
+  catalog_data_about_text        = "# ${title(each.key)} Application\n\nContainer image for the ${each.key} component."
+  catalog_data_usage_text        = "# Usage\n\ndocker pull public.ecr.aws/your-registry/${each.key}:latest"
 }
 ```
 
-### Advanced Configuration with Object-Based Catalog Data
+## Notes
 
-```hcl
-locals {
-  microservices = {
-    "api-gateway" = {
-      catalog_data = {
-        description       = "API Gateway service for microservices"
-        about_text        = "# API Gateway\n\nCentral API gateway handling authentication, routing, and rate limiting."
-        usage_text        = "# Usage\n\n```bash\ndocker run -p 8080:8080 public.ecr.aws/myregistry/api-gateway:latest\n```"
-        architectures     = ["x86-64", "ARM 64"]
-        operating_systems = ["Linux"]
-      }
-      tags = {
-        Type = "gateway"
-        Tier = "frontend"
-      }
-    }
-    "user-service" = {
-      catalog_data = {
-        description       = "User management microservice"
-        about_text        = "# User Service\n\nHandles user authentication, authorization, and profile management."
-        usage_text        = "# Usage\n\nRequires database connection and JWT configuration."
-        architectures     = ["x86-64"]
-        operating_systems = ["Linux"]
-      }
-      tags = {
-        Type = "service"
-        Tier = "backend"
-      }
-    }
-    "notification-service" = {
-      catalog_data = {
-        description       = "Notification delivery service"
-        about_text        = "# Notification Service\n\nAsynchronous notification processing with multiple delivery channels."
-        usage_text        = "# Usage\n\nConfigure SMTP, SMS, and push notification providers."
-        architectures     = ["x86-64"]
-        operating_systems = ["Linux"]
-      }
-      tags = {
-        Type = "service"
-        Tier = "backend"
-      }
-    }
-  }
-}
+- ECR Public repositories must be managed in `us-east-1`.
+- The live Terraform example in this directory keeps `source = "../.."` so CI validates the checked-out module.
+- Use descriptive `for_each` keys because they become repository names.
 
-module "microservices" {
-  source   = "lgallard/ecrpublic/aws"
-  for_each = local.microservices
+<!-- BEGIN_TF_DOCS -->
 
-  repository_name = each.key
-  catalog_data    = each.value.catalog_data
 
-  # Merge common and service-specific tags
-  tags = merge(
-    {
-      Project     = "microservices-platform"
-      Environment = "production"
-      ManagedBy   = "terraform"
-    },
-    each.value.tags
-  )
-}
-```
-
-### Mixed Configuration Approaches
-
-```hcl
-locals {
-  # Applications with different configuration patterns
-  applications = {
-    # Object-based configuration
-    "web-app" = {
-      type = "object"
-      config = {
-        description       = "Main web application"
-        about_text        = "# Web Application\n\nReact-based frontend application."
-        architectures     = ["x86-64", "ARM 64"]
-        operating_systems = ["Linux"]
-      }
-    }
-    # Variable-based configuration
-    "api-server" = {
-      type = "variables"
-      description = "REST API server"
-      about_text  = "# API Server\n\nNode.js REST API with Express framework."
-      architectures = ["x86-64"]
-      operating_systems = ["Linux"]
-    }
-  }
-}
-
-module "applications" {
-  source   = "lgallard/ecrpublic/aws"
-  for_each = local.applications
-
-  repository_name = each.key
-
-  # Conditional configuration based on type
-  catalog_data = each.value.type == "object" ? each.value.config : {}
-
-  # Variable-based configuration
-  catalog_data_description       = each.value.type == "variables" ? each.value.description : null
-  catalog_data_about_text        = each.value.type == "variables" ? each.value.about_text : null
-  catalog_data_architectures     = each.value.type == "variables" ? each.value.architectures : []
-  catalog_data_operating_systems = each.value.type == "variables" ? each.value.operating_systems : []
-
-  tags = {
-    Application = each.key
-    ManagedBy   = "terraform"
-  }
-}
-```
-
-## Outputs
-
-When using `for_each` with modules, outputs become maps keyed by the `for_each` key:
-
-```hcl
-# Output all repository URIs
-output "repository_uris" {
-  description = "Map of repository names to their URIs"
-  value = {
-    for k, v in module.public-ecr : k => v.repository_uri
-  }
-}
-
-# Output specific repository information
-output "frontend_repository_uri" {
-  description = "URI of the frontend repository"
-  value       = module.public-ecr["frontend"].repository_uri
-}
-
-# Output all repository information
-output "repositories" {
-  description = "Complete repository information"
-  value = {
-    for name, repo in module.public-ecr : name => {
-      name         = repo.repository_name
-      uri          = repo.repository_uri
-      arn          = repo.arn
-      registry_id  = repo.registry_id
-    }
-  }
-}
-```
-
-## Variable Configuration
-
-```hcl
-variable "registry_alias" {
-  description = "ECR Public registry alias"
-  type        = string
-  default     = "myorganization"
-}
-
-variable "environment" {
-  description = "Environment name"
-  type        = string
-  default     = "production"
-}
-
-variable "project_name" {
-  description = "Project name for tagging"
-  type        = string
-  default     = "microservices"
-}
-```
-
-## Best Practices
-
-1. **Use descriptive keys**: Repository names should be clear and meaningful
-2. **Leverage locals**: Define repository configurations in locals for better organization
-3. **Share common configuration**: Use merge() and conditional logic for shared settings
-4. **Consistent naming**: Follow a consistent naming convention for repositories
-5. **Proper tagging**: Include environment, project, and service tags for resource management
-6. **Catalog data quality**: Ensure each repository has appropriate ECR Public Gallery content
-
-## Testing
-
-Test the configuration with:
-
-```bash
-terraform init
-terraform plan
-terraform apply
-```
-
-Verify repositories in the ECR Public Gallery:
-
-```bash
-aws ecr-public describe-repositories --region us-east-1
-```
-
-## Regional Considerations
-
-Remember that ECR Public repositories must be created in `us-east-1`:
-
-```hcl
-provider "aws" {
-  alias  = "ecr_public"
-  region = "us-east-1"
-}
-
-module "public-ecr" {
-  providers = {
-    aws = aws.ecr_public
-  }
-  # ... rest of configuration
-}
-```
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2, < 2.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0, < 7.0 |
 
 ## Providers
 
@@ -320,4 +102,5 @@ No resources.
 | <a name="output_repository_summary"></a> [repository\_summary](#output\_repository\_summary) | Summary of created repositories |
 | <a name="output_repository_uris"></a> [repository\_uris](#output\_repository\_uris) | Map of repository names to their URIs |
 | <a name="output_worker_repository_uri"></a> [worker\_repository\_uri](#output\_worker\_repository\_uri) | URI of the worker repository |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+<!-- END_TF_DOCS -->

--- a/examples/multiple_repositories/provider.tf
+++ b/examples/multiple_repositories/provider.tf
@@ -1,12 +1,12 @@
 # Provider configuration for multiple repositories example
 
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.2, < 2.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 5.0, < 7.0"
     }
   }
 }

--- a/examples/using_objects/README.md
+++ b/examples/using_objects/README.md
@@ -1,26 +1,44 @@
 # Using objects example
 
-```
-module "public-ecr" {
+This example creates one ECR Public repository and configures gallery catalog data through the `catalog_data` object.
 
+## Copy/paste usage
+
+Use this Registry source address in consumer configurations:
+
+```hcl
+provider "aws" {
+  region = "us-east-1"
+}
+
+module "public-ecr" {
   source = "lgallard/ecrpublic/aws"
 
   repository_name = "lgallard-public-repo"
 
   catalog_data = {
     about_text        = "# Public repo\nPut your description here using Markdown format"
-    architectures     = ["Linux"]
+    architectures     = ["x86-64"]
     description       = "Description"
-    logo_image_blob   = filebase64("image.png")
-    operating_systems = ["ARM"]
-    usage_text        = "# Usage\n How to use you image goes here. Use Markdown format"
+    operating_systems = ["Linux"]
+    usage_text        = "# Usage\nHow to use your image goes here. Use Markdown format."
   }
 }
 ```
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## Local example notes
+
+The live Terraform example in this directory keeps `source = "../.."` so CI validates the checked-out module. It also includes an optional `image.png` logo file and safely reads it only when present.
+
+<!-- BEGIN_TF_DOCS -->
+
+
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2, < 2.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0, < 7.0 |
 
 ## Providers
 
@@ -43,4 +61,5 @@ No inputs.
 ## Outputs
 
 No outputs.
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+<!-- END_TF_DOCS -->

--- a/examples/using_objects/main.tf
+++ b/examples/using_objects/main.tf
@@ -10,6 +10,6 @@ module "public-ecr" {
     description       = "Description"
     logo_image_blob   = can(fileexists("${path.module}/image.png")) ? filebase64("${path.module}/image.png") : null
     operating_systems = ["Linux"]
-    usage_text        = "# Usage\n How to use you image goes here. Use Markdown format"
+    usage_text        = "# Usage\nHow to use your image goes here. Use Markdown format."
   }
 }

--- a/examples/using_objects/provider.tf
+++ b/examples/using_objects/provider.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.2, < 2.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 7.0"
+    }
+  }
+}
+
 provider "aws" {
   region = "us-east-1"
 }

--- a/examples/using_variables/README.md
+++ b/examples/using_variables/README.md
@@ -1,26 +1,42 @@
 # Using variables example
-This example creates an public ECR registry using variables.
 
-```
+This is the complete minimal example for Terraform Registry users. It creates one ECR Public repository, configures the required AWS region, and supplies catalog data with individual variables.
+
+## Copy/paste usage
+
+Use this Registry source address in consumer configurations:
+
+```hcl
+provider "aws" {
+  region = "us-east-1"
+}
+
 module "public-ecr" {
-
   source = "lgallard/ecrpublic/aws"
 
   repository_name = "lgallard-public-repo"
 
   catalog_data_about_text        = "# Public repo\nPut your description here using Markdown format"
-  catalog_data_architectures     = ["Linux"]
+  catalog_data_architectures     = ["x86-64"]
   catalog_data_description       = "Description"
-  catalog_data_logo_image_blob   = filebase64("image.png")
-  catalog_data_operating_systems = ["ARM"]
-  catalog_data_usage_text        = "# Usage\n How to use you image goes here. Use Markdown format"
-
+  catalog_data_operating_systems = ["Linux"]
+  catalog_data_usage_text        = "# Usage\nHow to use your image goes here. Use Markdown format."
 }
 ```
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## Local example notes
+
+The live Terraform example in this directory keeps `source = "../.."` so CI validates the checked-out module. Optional logo data is intentionally left `null`; set `catalog_data_logo_image_blob` to a base64-encoded image only when you have a logo file.
+
+<!-- BEGIN_TF_DOCS -->
+
+
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2, < 2.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0, < 7.0 |
 
 ## Providers
 
@@ -45,7 +61,7 @@ No resources.
 | <a name="input_catalog_data_description"></a> [catalog\_data\_description](#input\_catalog\_data\_description) | A short description of the contents of the repository | `string` | `"Description"` | no |
 | <a name="input_catalog_data_logo_image_blob"></a> [catalog\_data\_logo\_image\_blob](#input\_catalog\_data\_logo\_image\_blob) | The base64-encoded repository logo payload | `string` | `null` | no |
 | <a name="input_catalog_data_operating_systems"></a> [catalog\_data\_operating\_systems](#input\_catalog\_data\_operating\_systems) | The operating systems that the images in the repository are compatible with | `list(string)` | <pre>[<br/>  "Linux"<br/>]</pre> | no |
-| <a name="input_catalog_data_usage_text"></a> [catalog\_data\_usage\_text](#input\_catalog\_data\_usage\_text) | Detailed information on how to use the contents of the repository | `string` | `"# Usage\n How to use you image goes here. Use Markdown format"` | no |
+| <a name="input_catalog_data_usage_text"></a> [catalog\_data\_usage\_text](#input\_catalog\_data\_usage\_text) | Detailed information on how to use the contents of the repository | `string` | `"# Usage\nHow to use your image goes here. Use Markdown format."` | no |
 | <a name="input_repository_name"></a> [repository\_name](#input\_repository\_name) | Name of the repository | `string` | `"lgallard-public-repo"` | no |
 
 ## Outputs
@@ -62,4 +78,5 @@ No resources.
 | <a name="output_repository_uri"></a> [repository\_uri](#output\_repository\_uri) | The URI of the repository |
 | <a name="output_repository_url"></a> [repository\_url](#output\_repository\_url) | The URL of the repository |
 | <a name="output_tags_all"></a> [tags\_all](#output\_tags\_all) | A map of tags assigned to the resource, including those inherited from the provider default\_tags |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+<!-- END_TF_DOCS -->

--- a/examples/using_variables/provider.tf
+++ b/examples/using_variables/provider.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.2, < 2.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 7.0"
+    }
+  }
+}
+
 provider "aws" {
   region = "us-east-1"
 }

--- a/examples/using_variables/variables.tf
+++ b/examples/using_variables/variables.tf
@@ -37,5 +37,5 @@ variable "catalog_data_operating_systems" {
 variable "catalog_data_usage_text" {
   description = "Detailed information on how to use the contents of the repository"
   type        = string
-  default     = "# Usage\n How to use you image goes here. Use Markdown format"
+  default     = "# Usage\nHow to use your image goes here. Use Markdown format."
 }

--- a/examples/with_auth_token/README.md
+++ b/examples/with_auth_token/README.md
@@ -1,173 +1,70 @@
-# ECR Public with Authorization Token Example
+# ECR Public with authorization token example
 
-This example demonstrates how to create an ECR Public repository alongside retrieving authorization tokens for programmatic image pushing.
+This example creates an ECR Public repository and retrieves an authorization token for Docker login and push workflows.
 
-## Overview
+## Copy/paste usage
 
-The `aws_ecrpublic_authorization_token` data source provides authentication tokens needed to push images to ECR Public repositories. This example shows how to use this data source with the ECR Public module for complete CI/CD integration.
-
-## Key Features
-
-- ECR Public repository creation with catalog data
-- Authorization token retrieval for Docker authentication
-- Pre-configured outputs for Docker login commands
-- Regional constraint handling (us-east-1 requirement)
-
-## Important Notes
-
-### Regional Constraints
-
-- **ECR Public repositories must be created in `us-east-1` region**
-- **Authorization tokens must also be retrieved from `us-east-1`**
-- This is an AWS service limitation for ECR Public Gallery
-
-### Token Expiration
-
-- Authorization tokens expire after 12 hours
-- Tokens should be refreshed for long-running CI/CD processes
-- Use the `token_expires_at` output to monitor expiration
-
-## Usage
-
-### Basic Example
+Use this Registry source address in consumer configurations:
 
 ```hcl
-module "public-ecr-with-auth" {
-  source = "lgallard/ecrpublic/aws//examples/with_auth_token"
+provider "aws" {
+  region = "us-east-1"
+}
+
+# Authorization tokens for ECR Public must be requested from us-east-1.
+data "aws_ecrpublic_authorization_token" "token" {}
+
+module "public-ecr" {
+  source = "lgallard/ecrpublic/aws"
 
   repository_name = "my-application"
 
-  catalog_data_description = "My public application container"
-  catalog_data_about_text = <<-EOT
-    # My Application
+  catalog_data = {
+    description       = "My application container"
+    about_text        = "# My Application\n\nProduction-ready container for my public application."
+    usage_text        = "# Usage\n\ndocker pull public.ecr.aws/your-registry/my-application:latest"
+    architectures     = ["x86-64"]
+    operating_systems = ["Linux"]
+  }
+}
 
-    Production-ready container for my public application.
-  EOT
+output "repository_uri" {
+  value = module.public-ecr.repository_uri
+}
+
+output "authorization_token" {
+  value     = data.aws_ecrpublic_authorization_token.token.authorization_token
+  sensitive = true
 }
 ```
 
-### CI/CD Integration
+## Docker login
 
 ```bash
-# Retrieve outputs
-REPO_URI=$(terraform output -raw repository_uri)
-AUTH_TOKEN=$(terraform output -raw authorization_token)
-
-# Docker login using authorization token
-echo "$AUTH_TOKEN" | docker login --username AWS --password-stdin public.ecr.aws
-
-# Or use AWS CLI (recommended)
 aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
-
-# Tag and push image
-docker tag my-app:latest $REPO_URI:latest
-docker push $REPO_URI:latest
 ```
 
-### GitHub Actions Example
+## Notes
 
-```yaml
-name: Push to ECR Public
-on:
-  push:
-    branches: [main]
+- Authorization tokens expire after 12 hours.
+- Treat token outputs as sensitive and avoid logging them.
+- The live Terraform example in this directory keeps `source = "../.."` so CI validates the checked-out module.
 
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+<!-- BEGIN_TF_DOCS -->
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
 
-      - name: Login to ECR Public
-        run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
-
-      - name: Build and push
-        run: |
-          docker build -t ${{ secrets.ECR_REPOSITORY_URI }}:latest .
-          docker push ${{ secrets.ECR_REPOSITORY_URI }}:latest
-```
-
-## Inputs
-
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| repository_name | Name of the repository | `string` | `"my-app"` | no |
-| catalog_data_description | Public description visible in ECR Public Gallery | `string` | `"My application container"` | no |
-| catalog_data_about_text | Public about text in markdown format | `string` | See variables.tf | no |
-| catalog_data_usage_text | Public usage instructions in markdown format | `string` | See variables.tf | no |
-| catalog_data_architectures | Supported architectures for container images | `list(string)` | `["x86-64"]` | no |
-| catalog_data_operating_systems | Supported operating systems for container images | `list(string)` | `["Linux"]` | no |
-
-## Outputs
-
-| Name | Description | Sensitive |
-|------|-------------|:---------:|
-| repository_name | Name of the repository | no |
-| repository_uri | The URI of the repository | no |
-| repository_url | The URL of the repository | no |
-| repository_arn | Full ARN of the repository | no |
-| registry_id | The registry ID where the repository was created | no |
-| authorization_token | The authorization token (base64 encoded) | yes |
-| token_expires_at | Token expiration timestamp | no |
-| docker_login_command | Docker login command for ECR Public | no |
-| aws_cli_login_command | AWS CLI command to login to ECR Public | no |
-
-## Security Considerations
-
-1. **Token Sensitivity**: Authorization tokens are marked as sensitive and should not be logged
-2. **Token Expiration**: Implement token refresh logic for long-running processes
-3. **Regional Compliance**: Ensure all ECR Public operations use us-east-1 region
-4. **Access Control**: Limit ECR Public permissions to necessary operations only
-
-## Common Issues
-
-### "Repository does not exist" Error
-Ensure the repository is created before attempting authentication operations.
-
-### "No authorization token" Error
-Verify that:
-- AWS credentials are properly configured
-- The AWS provider is configured for us-east-1 region
-- IAM permissions include `ecr-public:GetAuthorizationToken`
-
-### Token Expiration
-Authorization tokens expire after 12 hours. Implement refresh logic:
-
-```bash
-# Check token expiration
-TOKEN_EXPIRES=$(terraform output -raw token_expires_at)
-CURRENT_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-
-if [[ "$CURRENT_TIME" > "$TOKEN_EXPIRES" ]]; then
-  echo "Token expired, refreshing..."
-  terraform refresh
-fi
-```
-
-## References
-
-- [aws_ecrpublic_authorization_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecrpublic_authorization_token)
-- [ECR Public User Guide](https://docs.aws.amazon.com/AmazonECR/latest/public/)
-- [Docker CLI Reference](https://docs.docker.com/engine/reference/commandline/login/)
-
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2, < 2.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0, < 7.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.27.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
 
 ## Modules
 
@@ -205,4 +102,5 @@ No requirements.
 | <a name="output_repository_uri"></a> [repository\_uri](#output\_repository\_uri) | The URI of the repository |
 | <a name="output_repository_url"></a> [repository\_url](#output\_repository\_url) | The URL of the repository |
 | <a name="output_token_expires_at"></a> [token\_expires\_at](#output\_token\_expires\_at) | Token expiration timestamp |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+<!-- END_TF_DOCS -->

--- a/examples/with_auth_token/main.tf
+++ b/examples/with_auth_token/main.tf
@@ -1,18 +1,3 @@
-terraform {
-  required_version = ">= 1.2, < 2.0"
-
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = ">= 5.0, < 7.0"
-    }
-  }
-}
-
-provider "aws" {
-  region = "us-east-1"
-}
-
 # Authorization token for ECR Public
 # Note: Must be used in us-east-1 region
 data "aws_ecrpublic_authorization_token" "token" {}

--- a/examples/with_auth_token/main.tf
+++ b/examples/with_auth_token/main.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.2, < 2.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 7.0"
+    }
+  }
+}
+
 provider "aws" {
   region = "us-east-1"
 }

--- a/examples/with_auth_token/provider.tf
+++ b/examples/with_auth_token/provider.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.2, < 2.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 7.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}

--- a/examples/with_repository_policy/README.md
+++ b/examples/with_repository_policy/README.md
@@ -1,28 +1,16 @@
-# ECR Public Repository with Policy Example
+# ECR Public repository with policy example
 
-This example demonstrates how to create an ECR Public repository with a repository policy to control push access for CI/CD systems and cross-account scenarios.
+This example creates an ECR Public repository and attaches an optional repository policy to control push access for CI/CD systems or trusted AWS principals.
 
-## Overview
+## Copy/paste usage
 
-Repository policies for ECR Public allow you to control who can push images to your public repository while maintaining public read access. This is particularly useful for:
-
-- **CI/CD Systems**: Grant push access to specific roles used by GitHub Actions, GitLab CI, or other automation tools
-- **Cross-Account Access**: Allow other AWS accounts to push images to your repository
-- **Team-based Access**: Control which IAM users or roles within your organization can push updates
-
-## Prerequisites
-
-- Terraform >= 1.0
-- AWS CLI configured with appropriate credentials
-- ECR Public repositories must be created in the `us-east-1` region
-
-## Repository Policy Patterns
-
-### 1. CI/CD Push Access
-
-Grant push access to a specific CI/CD role (e.g., GitHub Actions):
+Use this Registry source address in consumer configurations:
 
 ```hcl
+provider "aws" {
+  region = "us-east-1"
+}
+
 module "public-ecr" {
   source = "lgallard/ecrpublic/aws"
 
@@ -58,261 +46,22 @@ module "public-ecr" {
 }
 ```
 
-### 2. Cross-Account Access
+## Notes
 
-Allow another AWS account to push images:
+- ECR Public repositories must be managed in `us-east-1`.
+- Public pull access is inherent to ECR Public; repository policies here control push-related access.
+- Replace the example IAM principal ARN with a real role from your account.
+- The live Terraform example in this directory keeps `source = "../.."` so CI validates the checked-out module.
 
-```hcl
-repository_policy = jsonencode({
-  Version = "2012-10-17"
-  Statement = [
-    {
-      Sid       = "AllowCrossAccountPush"
-      Effect    = "Allow"
-      Principal = {
-        AWS = "arn:aws:iam::987654321098:root"
-      }
-      Action = [
-        "ecr-public:BatchCheckLayerAvailability",
-        "ecr-public:PutImage",
-        "ecr-public:InitiateLayerUpload",
-        "ecr-public:UploadLayerPart",
-        "ecr-public:CompleteLayerUpload"
-      ]
-      Condition = {
-        StringEquals = {
-          "ecr-public:username" = "allowed-user"
-        }
-      }
-    }
-  ]
-})
-```
+<!-- BEGIN_TF_DOCS -->
 
-### 3. Multiple Roles with Different Permissions
 
-Grant different levels of access to multiple principals:
-
-```hcl
-repository_policy = jsonencode({
-  Version = "2012-10-17"
-  Statement = [
-    {
-      Sid       = "AllowDevelopmentPush"
-      Effect    = "Allow"
-      Principal = {
-        AWS = [
-          "arn:aws:iam::123456789012:role/DeveloperRole",
-          "arn:aws:iam::123456789012:role/GitHubActionsRole"
-        ]
-      }
-      Action = [
-        "ecr-public:BatchCheckLayerAvailability",
-        "ecr-public:PutImage",
-        "ecr-public:InitiateLayerUpload",
-        "ecr-public:UploadLayerPart",
-        "ecr-public:CompleteLayerUpload"
-      ]
-    },
-    {
-      Sid       = "AllowProductionPushWithCondition"
-      Effect    = "Allow"
-      Principal = {
-        AWS = "arn:aws:iam::123456789012:role/ProductionDeployRole"
-      }
-      Action = [
-        "ecr-public:BatchCheckLayerAvailability",
-        "ecr-public:PutImage",
-        "ecr-public:InitiateLayerUpload",
-        "ecr-public:UploadLayerPart",
-        "ecr-public:CompleteLayerUpload"
-      ]
-      Condition = {
-        StringLike = {
-          "ecr-public:image-tag" = ["v*", "release-*"]
-        }
-      }
-    }
-  ]
-})
-```
-
-## Usage
-
-### Basic Example
-
-1. **Configure variables** in `terraform.tfvars`:
-
-```hcl
-repository_name = "my-company-app"
-
-create_repository_policy = true
-
-repository_policy = jsonencode({
-  Version = "2012-10-17"
-  Statement = [
-    {
-      Sid       = "AllowPushFromCICD"
-      Effect    = "Allow"
-      Principal = {
-        AWS = "arn:aws:iam::123456789012:role/GitHubActionsRole"
-      }
-      Action = [
-        "ecr-public:BatchCheckLayerAvailability",
-        "ecr-public:PutImage",
-        "ecr-public:InitiateLayerUpload",
-        "ecr-public:UploadLayerPart",
-        "ecr-public:CompleteLayerUpload"
-      ]
-    }
-  ]
-})
-
-catalog_data = {
-  description       = "My company's public application"
-  about_text        = "# My Company App\n\nA production-ready containerized application."
-  usage_text        = "# Usage\n\n```bash\ndocker pull public.ecr.aws/my-registry/my-company-app:latest\ndocker run -p 8080:8080 public.ecr.aws/my-registry/my-company-app:latest\n```"
-  architectures     = ["x86-64", "ARM 64"]
-  operating_systems = ["Linux"]
-}
-
-tags = {
-  Environment = "production"
-  Team        = "platform"
-  ManagedBy   = "terraform"
-}
-```
-
-2. **Deploy the infrastructure**:
-
-```bash
-terraform init
-terraform plan
-terraform apply
-```
-
-### With GitHub Actions Integration
-
-For GitHub Actions integration, your workflow needs the appropriate IAM role. Here's an example setup:
-
-**GitHub Actions Workflow:**
-```yaml
-name: Build and Push to ECR Public
-
-on:
-  push:
-    branches: [main]
-
-permissions:
-  id-token: write
-  contents: read
-
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::123456789012:role/GitHubActionsRole
-          aws-region: us-east-1
-
-      - name: Login to Amazon ECR Public
-        id: login-ecr-public
-        uses: aws-actions/amazon-ecr-login@v2
-        with:
-          registry-type: public
-
-      - name: Build and push image
-        env:
-          REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
-          REPOSITORY: my-public-app
-          IMAGE_TAG: ${{ github.sha }}
-        run: |
-          docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG .
-          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
-```
-
-## Important Notes
-
-### ECR Public Specifics
-
-- **Region Constraint**: ECR Public repositories must be created in `us-east-1`
-- **Public Access**: All images are publicly accessible for pull; policies only control push access
-- **Global Availability**: Images can be pulled from any AWS region despite being stored in `us-east-1`
-
-### Security Considerations
-
-- **Principle of Least Privilege**: Only grant the minimum permissions required
-- **Condition-Based Access**: Use conditions to restrict access based on image tags, time, or other factors
-- **Regular Review**: Periodically review and update repository policies
-- **Logging**: Enable CloudTrail to monitor repository access and changes
-
-### Policy Actions
-
-Common ECR Public actions for repository policies:
-
-- `ecr-public:BatchCheckLayerAvailability`: Check if layers exist
-- `ecr-public:PutImage`: Push completed images
-- `ecr-public:InitiateLayerUpload`: Start uploading image layers
-- `ecr-public:UploadLayerPart`: Upload parts of image layers
-- `ecr-public:CompleteLayerUpload`: Complete layer upload
-
-### Troubleshooting
-
-**Common Issues:**
-
-1. **Permission Denied**: Ensure the IAM role/user has the necessary ECR Public permissions
-2. **Policy Validation**: Repository policies must be valid JSON with proper IAM syntax
-3. **Region Issues**: Remember that ECR Public operations must target `us-east-1`
-
-**Verification:**
-
-```bash
-# Check repository policy
-aws ecr-public get-repository-policy --repository-name my-public-app --region us-east-1
-
-# List repositories
-aws ecr-public describe-repositories --region us-east-1
-
-# Test push access (after proper authentication)
-docker tag my-app:latest public.ecr.aws/my-registry/my-public-app:latest
-docker push public.ecr.aws/my-registry/my-public-app:latest
-```
-
-## Outputs
-
-This example provides the following outputs:
-
-- `repository_uri`: The full URI for pulling/pushing images
-- `repository_name`: The name of the created repository
-- `registry_id`: The registry ID where the repository was created
-- `repository_arn`: The ARN of the repository
-- `repository_policy`: The applied repository policy JSON
-
-## Resources Created
-
-- **aws_ecrpublic_repository**: The ECR Public repository
-- **aws_ecrpublic_repository_policy**: The repository access policy (if `create_repository_policy = true`)
-
-## Clean Up
-
-To remove all resources created by this example:
-
-```bash
-terraform destroy
-```
-
-Note: Ensure the repository is empty before destruction, as repositories containing images cannot be deleted.
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2, < 2.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0, < 7.0 |
 
 ## Providers
 
@@ -347,4 +96,5 @@ No resources.
 | <a name="output_repository_name"></a> [repository\_name](#output\_repository\_name) | The name of the repository |
 | <a name="output_repository_policy"></a> [repository\_policy](#output\_repository\_policy) | The repository policy JSON |
 | <a name="output_repository_uri"></a> [repository\_uri](#output\_repository\_uri) | The URI of the repository |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+<!-- END_TF_DOCS -->

--- a/examples/with_repository_policy/provider.tf
+++ b/examples/with_repository_policy/provider.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.2, < 2.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 5.0, < 7.0"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Document Terraform Registry compatibility and identify `examples/using_variables` as the complete minimal example
- Normalize root/example README copy-paste snippets to use `source = "lgallard/ecrpublic/aws"` and `us-east-1`
- Remove stale duplicate generated docs blocks and keep terraform-docs output under the repo template markers
- Align example Terraform constraints with the root module (`>= 1.2, < 2.0`, AWS provider `< 7.0`)
- Update the terraform-docs pre-commit hook to rely on `.terraform-docs.yml` and avoid duplicate legacy docs blocks

Closes #6

## Validation
- [x] `terraform fmt -check -recursive`
- [x] `terraform-docs --output-check` for root and all examples
- [x] `terraform validate` for root and all examples
- [x] `pre-commit run --all-files`
- [ ] GitHub CI
- [ ] `@codebot hunt`
