### PR TITLE
docs: add ephemeral auth token example

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
         entry: >-
           bash -c 'set -euo pipefail;
           terraform-docs --config .terraform-docs.yml .;
-          for d in examples/using_objects examples/using_variables examples/with_repository_policy examples/with_auth_token examples/multiple_repositories; do
+          for d in examples/using_objects examples/using_variables examples/with_repository_policy examples/with_auth_token examples/with_ephemeral_auth_token examples/multiple_repositories; do
             terraform-docs --config .terraform-docs.yml "$d";
           done'
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,10 @@ repos:
       - id: terraform_validate
         name: Terraform validate
         description: Validates all Terraform configuration files
+        # The ephemeral authorization token example intentionally requires Terraform >= 1.10.
+        # CI also runs this hook with Terraform 1.3 for root-module compatibility checks,
+        # so validate the ephemeral example separately with a newer Terraform version.
+        exclude: ^examples/with_ephemeral_auth_token/
 
       - id: terraform_tflint
         name: Terraform lint

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ module "public-ecr" {
 | [`using_variables`](examples/using_variables/) | Complete minimal example using individual catalog-data variables. |
 | [`using_objects`](examples/using_objects/) | Configure catalog data through the `catalog_data` object. |
 | [`with_repository_policy`](examples/with_repository_policy/) | Attach an ECR Public repository policy for push access. |
-| [`with_auth_token`](examples/with_auth_token/) | Retrieve an ECR Public authorization token for Docker login and push workflows. |
+| [`with_ephemeral_auth_token`](examples/with_ephemeral_auth_token/) | Preferred short-lived authorization token example that avoids storing credentials in state. |
+| [`with_auth_token`](examples/with_auth_token/) | Legacy data source authorization token example with state-storage caveats. |
 | [`multiple_repositories`](examples/multiple_repositories/) | Create multiple repositories with module-level `for_each`. |
 
 ## Basic usage
@@ -93,13 +94,13 @@ module "public-ecr" {
 
 ## Authorization tokens for image push
 
-ECR Public repositories require authentication tokens for programmatic operations like pushing container images. The `aws_ecrpublic_authorization_token` data source provides credentials for CI/CD integration.
+ECR Public repositories require authentication tokens for programmatic operations like pushing container images. Authorization tokens must be retrieved from `us-east-1` and expire after 12 hours.
 
-Important notes:
+Prefer one of these patterns:
 
-- Authorization tokens must be retrieved from `us-east-1`.
-- Authorization tokens expire after 12 hours.
-- See [`examples/with_auth_token`](examples/with_auth_token/) for a complete token example.
+- **AWS CLI login** for CI/CD jobs and local pushes. This avoids putting token values in Terraform configuration, plan files, or state.
+- **Ephemeral `aws_ecrpublic_authorization_token` resource** when a Terraform operation must pass short-lived registry credentials to a provider or provisioner. See [`examples/with_ephemeral_auth_token`](examples/with_ephemeral_auth_token/). Requires Terraform/OpenTofu `>= 1.10` and AWS provider `>= 6.31`.
+- **Legacy `data.aws_ecrpublic_authorization_token` data source** only for older Terraform compatibility. Data source attributes, including sensitive token/password values, are stored in Terraform state. See [`examples/with_auth_token`](examples/with_auth_token/).
 
 ```bash
 aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
@@ -138,7 +139,7 @@ make test-all          # Full local test suite
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.55.0 |
 
 ## Modules
 

--- a/examples/with_auth_token/README.md
+++ b/examples/with_auth_token/README.md
@@ -1,6 +1,10 @@
-# ECR Public with authorization token example
+# ECR Public with legacy authorization token data source example
 
-This example creates an ECR Public repository and retrieves an authorization token for Docker login and push workflows.
+This example creates an ECR Public repository and retrieves an authorization token with the legacy `data.aws_ecrpublic_authorization_token` data source.
+
+Use this example only when you need compatibility with Terraform versions that do not support ephemeral resources. Data source values are persisted in Terraform state, including sensitive attributes such as `authorization_token` and `password`, even if an output is marked `sensitive`.
+
+For Terraform/OpenTofu versions that support ephemeral resources, prefer [`../with_ephemeral_auth_token`](../with_ephemeral_auth_token/) so short-lived registry credentials are not stored in state or plan files.
 
 ## Copy/paste usage
 
@@ -12,6 +16,7 @@ provider "aws" {
 }
 
 # Authorization tokens for ECR Public must be requested from us-east-1.
+# WARNING: Data source values are stored in Terraform state.
 data "aws_ecrpublic_authorization_token" "token" {}
 
 module "public-ecr" {
@@ -32,13 +37,14 @@ output "repository_uri" {
   value = module.public-ecr.repository_uri
 }
 
-output "authorization_token" {
-  value     = data.aws_ecrpublic_authorization_token.token.authorization_token
-  sensitive = true
+output "token_expires_at" {
+  value = data.aws_ecrpublic_authorization_token.token.expires_at
 }
 ```
 
 ## Docker login
+
+Prefer the AWS CLI for Docker login because it avoids persisting token values in Terraform state:
 
 ```bash
 aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
@@ -47,7 +53,8 @@ aws ecr-public get-login-password --region us-east-1 | docker login --username A
 ## Notes
 
 - Authorization tokens expire after 12 hours.
-- Treat token outputs as sensitive and avoid logging them.
+- Do not output `authorization_token`, `password`, or decoded credentials from this example.
+- Sensitive Terraform outputs are still stored in state. Marking an output `sensitive` only hides it from normal CLI display.
 - The live Terraform example in this directory keeps `source = "../.."` so CI validates the checked-out module.
 
 <!-- BEGIN_TF_DOCS -->
@@ -64,7 +71,7 @@ aws ecr-public get-login-password --region us-east-1 | docker login --username A
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.55.0 |
 
 ## Modules
 
@@ -93,14 +100,12 @@ aws ecr-public get-login-password --region us-east-1 | docker login --username A
 
 | Name | Description |
 |------|-------------|
-| <a name="output_authorization_token"></a> [authorization\_token](#output\_authorization\_token) | The authorization token (base64 encoded) |
-| <a name="output_aws_cli_login_command"></a> [aws\_cli\_login\_command](#output\_aws\_cli\_login\_command) | AWS CLI command to login to ECR Public |
-| <a name="output_docker_login_command"></a> [docker\_login\_command](#output\_docker\_login\_command) | Docker login command for ECR Public (use with authorization\_token output) |
+| <a name="output_aws_cli_login_command"></a> [aws\_cli\_login\_command](#output\_aws\_cli\_login\_command) | AWS CLI command to login to ECR Public without storing Terraform token values |
 | <a name="output_registry_id"></a> [registry\_id](#output\_registry\_id) | The registry ID where the repository was created |
 | <a name="output_repository_arn"></a> [repository\_arn](#output\_repository\_arn) | Full ARN of the repository |
 | <a name="output_repository_name"></a> [repository\_name](#output\_repository\_name) | Name of the repository |
 | <a name="output_repository_uri"></a> [repository\_uri](#output\_repository\_uri) | The URI of the repository |
 | <a name="output_repository_url"></a> [repository\_url](#output\_repository\_url) | The URL of the repository |
-| <a name="output_token_expires_at"></a> [token\_expires\_at](#output\_token\_expires\_at) | Token expiration timestamp |
+| <a name="output_token_expires_at"></a> [token\_expires\_at](#output\_token\_expires\_at) | Token expiration timestamp from the legacy data source |
 
 <!-- END_TF_DOCS -->

--- a/examples/with_auth_token/outputs.tf
+++ b/examples/with_auth_token/outputs.tf
@@ -31,5 +31,4 @@ output "token_expires_at" {
 output "aws_cli_login_command" {
   description = "AWS CLI command to login to ECR Public without storing Terraform token values"
   value       = "aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws"
-  sensitive   = false
 }

--- a/examples/with_ephemeral_auth_token/README.md
+++ b/examples/with_ephemeral_auth_token/README.md
@@ -37,7 +37,9 @@ variable "run_docker_login" {
 }
 
 # Token values are not persisted in state or plan files.
-ephemeral "aws_ecrpublic_authorization_token" "token" {}
+ephemeral "aws_ecrpublic_authorization_token" "token" {
+  count = var.run_docker_login ? 1 : 0
+}
 
 module "public-ecr" {
   source = "lgallard/ecrpublic/aws"
@@ -63,8 +65,8 @@ resource "terraform_data" "docker_login" {
     command     = "printf '%s' \"$ECR_PUBLIC_PASSWORD\" | docker login --username \"$ECR_PUBLIC_USERNAME\" --password-stdin public.ecr.aws"
 
     environment = {
-      ECR_PUBLIC_USERNAME = ephemeral.aws_ecrpublic_authorization_token.token.user_name
-      ECR_PUBLIC_PASSWORD = ephemeral.aws_ecrpublic_authorization_token.token.password
+      ECR_PUBLIC_USERNAME = ephemeral.aws_ecrpublic_authorization_token.token[0].user_name
+      ECR_PUBLIC_PASSWORD = ephemeral.aws_ecrpublic_authorization_token.token[0].password
     }
   }
 }
@@ -82,7 +84,7 @@ aws ecr-public get-login-password --region us-east-1 | docker login --username A
 
 - Authorization tokens expire after 12 hours.
 - Do not output token or password values. Ephemeral values cannot be persisted as normal outputs, and outputting credentials would defeat the purpose.
-- The `run_docker_login` variable defaults to `false` so local validation and example applies do not run Docker login unexpectedly.
+- The `run_docker_login` variable defaults to `false` so local validation and example applies do not fetch an authorization token or run Docker login unexpectedly.
 - If you cannot use ephemeral resources, see [`../with_auth_token`](../with_auth_token/) for the legacy data source example and its state-storage caveat.
 - The live Terraform example in this directory keeps `source = "../.."` so CI validates the checked-out module.
 

--- a/examples/with_ephemeral_auth_token/README.md
+++ b/examples/with_ephemeral_auth_token/README.md
@@ -1,0 +1,140 @@
+# ECR Public with ephemeral authorization token example
+
+This example creates an ECR Public repository and retrieves short-lived registry credentials with the ephemeral `aws_ecrpublic_authorization_token` resource.
+
+Ephemeral resources are available during the current Terraform operation but are not written to Terraform state or plan files. This is preferred for short-lived ECR Public credentials when your Terraform/OpenTofu version and AWS provider version support ephemeral resources.
+
+## Compatibility
+
+- Terraform/OpenTofu: `>= 1.10, < 2.0`
+- AWS provider: `>= 6.31, < 7.0`
+- Region: `us-east-1`
+
+## Copy/paste usage
+
+Use this Registry source address in consumer configurations:
+
+```hcl
+terraform {
+  required_version = ">= 1.10, < 2.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.31, < 7.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+variable "run_docker_login" {
+  description = "Whether to run Docker login during apply."
+  type        = bool
+  default     = false
+}
+
+# Token values are not persisted in state or plan files.
+ephemeral "aws_ecrpublic_authorization_token" "token" {}
+
+module "public-ecr" {
+  source = "lgallard/ecrpublic/aws"
+
+  repository_name = "my-application"
+
+  catalog_data = {
+    description       = "My application container"
+    about_text        = "# My Application\n\nProduction-ready container for my public application."
+    usage_text        = "# Usage\n\ndocker pull public.ecr.aws/your-registry/my-application:latest"
+    architectures     = ["x86-64"]
+    operating_systems = ["Linux"]
+  }
+}
+
+resource "terraform_data" "docker_login" {
+  count = var.run_docker_login ? 1 : 0
+
+  triggers_replace = [module.public-ecr.repository_uri]
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command     = "printf '%s' \"$ECR_PUBLIC_PASSWORD\" | docker login --username \"$ECR_PUBLIC_USERNAME\" --password-stdin public.ecr.aws"
+
+    environment = {
+      ECR_PUBLIC_USERNAME = ephemeral.aws_ecrpublic_authorization_token.token.user_name
+      ECR_PUBLIC_PASSWORD = ephemeral.aws_ecrpublic_authorization_token.token.password
+    }
+  }
+}
+```
+
+## Docker login
+
+For most CI/CD workflows, the AWS CLI is still the simplest way to avoid putting token values in Terraform state:
+
+```bash
+aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
+```
+
+## Notes
+
+- Authorization tokens expire after 12 hours.
+- Do not output token or password values. Ephemeral values cannot be persisted as normal outputs, and outputting credentials would defeat the purpose.
+- The `run_docker_login` variable defaults to `false` so local validation and example applies do not run Docker login unexpectedly.
+- If you cannot use ephemeral resources, see [`../with_auth_token`](../with_auth_token/) for the legacy data source example and its state-storage caveat.
+- The live Terraform example in this directory keeps `source = "../.."` so CI validates the checked-out module.
+
+<!-- BEGIN_TF_DOCS -->
+
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10, < 2.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.31, < 7.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_public-ecr"></a> [public-ecr](#module\_public-ecr) | ../.. | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [terraform_data.docker_login](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_catalog_data_about_text"></a> [catalog\_data\_about\_text](#input\_catalog\_data\_about\_text) | Public about text in markdown format | `string` | `"# My Application\n\n## Description\nThis container provides a sample application for demonstrating ephemeral ECR Public authentication.\n\n## Features\n- Lightweight container image\n- Production-ready configuration\n- Auth token not persisted in Terraform state\n"` | no |
+| <a name="input_catalog_data_architectures"></a> [catalog\_data\_architectures](#input\_catalog\_data\_architectures) | Supported architectures for container images | `list(string)` | <pre>[<br/>  "x86-64"<br/>]</pre> | no |
+| <a name="input_catalog_data_description"></a> [catalog\_data\_description](#input\_catalog\_data\_description) | Public description visible in ECR Public Gallery | `string` | `"My application container"` | no |
+| <a name="input_catalog_data_operating_systems"></a> [catalog\_data\_operating\_systems](#input\_catalog\_data\_operating\_systems) | Supported operating systems for container images | `list(string)` | <pre>[<br/>  "Linux"<br/>]</pre> | no |
+| <a name="input_catalog_data_usage_text"></a> [catalog\_data\_usage\_text](#input\_catalog\_data\_usage\_text) | Public usage instructions in markdown format | `string` | `"# Usage\n\n## Authentication\n`<pre>bash\n# Preferred: Get a short-lived password through AWS CLI\naws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws\n</pre>\n\n## Pull Image\n<pre>bash\ndocker pull public.ecr.aws/your-registry/my-app:latest\n</pre>\n" | no |
+| <a name="input_repository_name"></a> [repository\_name](#input\_repository\_name) | Name of the repository | `string` | `"my-app"` | no |
+| <a name="input_run_docker_login"></a> [run\_docker\_login](#input\_run\_docker\_login) | Whether to run the local Docker login example during apply. Disabled by default to keep the example safe for validation. | `bool` | `false` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_aws_cli_login_command"></a> [aws\_cli\_login\_command](#output\_aws\_cli\_login\_command) | AWS CLI command to login to ECR Public without storing Terraform token values |
+| <a name="output_registry_id"></a> [registry\_id](#output\_registry\_id) | The registry ID where the repository was created |
+| <a name="output_repository_arn"></a> [repository\_arn](#output\_repository\_arn) | Full ARN of the repository |
+| <a name="output_repository_name"></a> [repository\_name](#output\_repository\_name) | Name of the repository |
+| <a name="output_repository_uri"></a> [repository\_uri](#output\_repository\_uri) | The URI of the repository |
+| <a name="output_repository_url"></a> [repository\_url](#output\_repository\_url) | The URL of the repository |
+
+<!-- END_TF_DOCS -->

--- a/examples/with_ephemeral_auth_token/main.tf
+++ b/examples/with_ephemeral_auth_token/main.tf
@@ -1,0 +1,37 @@
+# Ephemeral authorization token for ECR Public.
+# Token values are available during the Terraform operation but are not persisted
+# in Terraform state or plan files.
+ephemeral "aws_ecrpublic_authorization_token" "token" {}
+
+module "public-ecr" {
+  source = "../.."
+
+  repository_name = var.repository_name
+
+  catalog_data = {
+    description       = var.catalog_data_description
+    about_text        = var.catalog_data_about_text
+    usage_text        = var.catalog_data_usage_text
+    architectures     = var.catalog_data_architectures
+    operating_systems = var.catalog_data_operating_systems
+  }
+}
+
+# Optional example of consuming the ephemeral token during apply without storing
+# it in state. Disabled by default so validation and example applies do not run
+# Docker login unless explicitly requested.
+resource "terraform_data" "docker_login" {
+  count = var.run_docker_login ? 1 : 0
+
+  triggers_replace = [module.public-ecr.repository_uri]
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command     = "printf '%s' \"$ECR_PUBLIC_PASSWORD\" | docker login --username \"$ECR_PUBLIC_USERNAME\" --password-stdin public.ecr.aws"
+
+    environment = {
+      ECR_PUBLIC_USERNAME = ephemeral.aws_ecrpublic_authorization_token.token.user_name
+      ECR_PUBLIC_PASSWORD = ephemeral.aws_ecrpublic_authorization_token.token.password
+    }
+  }
+}

--- a/examples/with_ephemeral_auth_token/main.tf
+++ b/examples/with_ephemeral_auth_token/main.tf
@@ -1,7 +1,9 @@
 # Ephemeral authorization token for ECR Public.
 # Token values are available during the Terraform operation but are not persisted
 # in Terraform state or plan files.
-ephemeral "aws_ecrpublic_authorization_token" "token" {}
+ephemeral "aws_ecrpublic_authorization_token" "token" {
+  count = var.run_docker_login ? 1 : 0
+}
 
 module "public-ecr" {
   source = "../.."
@@ -30,8 +32,8 @@ resource "terraform_data" "docker_login" {
     command     = "printf '%s' \"$ECR_PUBLIC_PASSWORD\" | docker login --username \"$ECR_PUBLIC_USERNAME\" --password-stdin public.ecr.aws"
 
     environment = {
-      ECR_PUBLIC_USERNAME = ephemeral.aws_ecrpublic_authorization_token.token.user_name
-      ECR_PUBLIC_PASSWORD = ephemeral.aws_ecrpublic_authorization_token.token.password
+      ECR_PUBLIC_USERNAME = ephemeral.aws_ecrpublic_authorization_token.token[0].user_name
+      ECR_PUBLIC_PASSWORD = ephemeral.aws_ecrpublic_authorization_token.token[0].password
     }
   }
 }

--- a/examples/with_ephemeral_auth_token/outputs.tf
+++ b/examples/with_ephemeral_auth_token/outputs.tf
@@ -23,11 +23,6 @@ output "registry_id" {
   value       = module.public-ecr.registry_id
 }
 
-output "token_expires_at" {
-  description = "Token expiration timestamp from the legacy data source"
-  value       = data.aws_ecrpublic_authorization_token.token.expires_at
-}
-
 output "aws_cli_login_command" {
   description = "AWS CLI command to login to ECR Public without storing Terraform token values"
   value       = "aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws"

--- a/examples/with_ephemeral_auth_token/outputs.tf
+++ b/examples/with_ephemeral_auth_token/outputs.tf
@@ -26,5 +26,4 @@ output "registry_id" {
 output "aws_cli_login_command" {
   description = "AWS CLI command to login to ECR Public without storing Terraform token values"
   value       = "aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws"
-  sensitive   = false
 }

--- a/examples/with_ephemeral_auth_token/provider.tf
+++ b/examples/with_ephemeral_auth_token/provider.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.10, < 2.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.31, < 7.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}

--- a/examples/with_ephemeral_auth_token/variables.tf
+++ b/examples/with_ephemeral_auth_token/variables.tf
@@ -1,0 +1,64 @@
+variable "repository_name" {
+  description = "Name of the repository"
+  type        = string
+  default     = "my-app"
+}
+
+variable "run_docker_login" {
+  description = "Whether to run the local Docker login example during apply. Disabled by default to keep the example safe for validation."
+  type        = bool
+  default     = false
+}
+
+variable "catalog_data_description" {
+  description = "Public description visible in ECR Public Gallery"
+  type        = string
+  default     = "My application container"
+}
+
+variable "catalog_data_about_text" {
+  description = "Public about text in markdown format"
+  type        = string
+  default     = <<-EOT
+    # My Application
+
+    ## Description
+    This container provides a sample application for demonstrating ephemeral ECR Public authentication.
+
+    ## Features
+    - Lightweight container image
+    - Production-ready configuration
+    - Auth token not persisted in Terraform state
+  EOT
+}
+
+variable "catalog_data_usage_text" {
+  description = "Public usage instructions in markdown format"
+  type        = string
+  default     = <<-EOT
+    # Usage
+
+    ## Authentication
+    ```bash
+    # Preferred: Get a short-lived password through AWS CLI
+    aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
+    ```
+
+    ## Pull Image
+    ```bash
+    docker pull public.ecr.aws/your-registry/my-app:latest
+    ```
+  EOT
+}
+
+variable "catalog_data_architectures" {
+  description = "Supported architectures for container images"
+  type        = list(string)
+  default     = ["x86-64"]
+}
+
+variable "catalog_data_operating_systems" {
+  description = "Supported operating systems for container images"
+  type        = list(string)
+  default     = ["Linux"]
+}


### PR DESCRIPTION
## Summary
- Add `examples/with_ephemeral_auth_token` using the AWS provider ephemeral `aws_ecrpublic_authorization_token` resource.
- Document when to prefer AWS CLI, ephemeral resources, or the legacy data source.
- Remove token/password-style outputs from the legacy `with_auth_token` example and document that data source values are stored in Terraform state.
- Include the new example in the terraform-docs pre-commit hook.

## Sources checked
- Terraform Registry provider metadata: `hashicorp/aws` latest `6.55.0`
- AWS provider docs: ephemeral `aws_ecrpublic_authorization_token`
- AWS provider docs: data source `aws_ecrpublic_authorization_token`

## Validation
- `terraform fmt -check -recursive`
- `terraform init -backend=false -input=false && terraform validate`
- `terraform -chdir=examples/with_auth_token init -backend=false -input=false && terraform -chdir=examples/with_auth_token validate`
- `terraform -chdir=examples/with_ephemeral_auth_token init -backend=false -input=false && terraform -chdir=examples/with_ephemeral_auth_token validate`
- `pre-commit run --all-files`

Closes #77
