### PR TITLE
ci: restore pre-commit checks

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -591,8 +591,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--model claude-sonnet-4-6"
 
-          # Allow Bash permissions for targeted Terraform checks and documentation updates
-          allowed_tools: "Bash(terraform fmt),Bash(terraform validate),Bash(terraform-docs)"
+          # Allow Bash permissions for pre-commit hooks and documentation updates
+          allowed_tools: "Bash(pre-commit run --files),Bash(terraform fmt),Bash(terraform validate),Bash(terraform-docs)"
 
           # Dynamic prompt based on review mode
           direct_prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -71,8 +71,8 @@ jobs:
               }
             }
 
-          # Allow Bash permissions for targeted Terraform checks and documentation updates + MCP tools
-          allowed_tools: "Bash(terraform fmt),Bash(terraform validate),Bash(terraform-docs),mcp__terraform-server__getProviderDocs,mcp__terraform-server__resolveProviderDocID,mcp__terraform-server__searchModules,mcp__terraform-server__moduleDetails,mcp__context7__resolve-library-id,mcp__context7__get-library-docs"
+          # Allow Bash permissions for pre-commit hooks and documentation updates + MCP tools
+          allowed_tools: "Bash(pre-commit run --files),Bash(terraform fmt),Bash(terraform validate),Bash(terraform-docs),mcp__terraform-server__getProviderDocs,mcp__terraform-server__resolveProviderDocID,mcp__terraform-server__searchModules,mcp__terraform-server__moduleDetails,mcp__context7__resolve-library-id,mcp__context7__get-library-docs"
 
           # Optional: Add custom instructions for Claude to customize its behavior for your project
           # custom_instructions: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,12 +7,14 @@ on:
       - '**.tf'
       - '**.tfvars'
       - '.pre-commit-config.yaml'
+      - '.tflint.hcl'
   push:
     branches: [main]
     paths:
       - '**.tf'
       - '**.tfvars'
       - '.pre-commit-config.yaml'
+      - '.tflint.hcl'
 
 jobs:
   pre-commit:
@@ -24,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
 
@@ -39,8 +41,9 @@ jobs:
           terraform_version: '1.3.0'
 
       - name: Install tflint
-        run: |
-          curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
+        uses: terraform-linters/setup-tflint@v4
+        with:
+          tflint_version: v0.54.0
 
       - name: Install pre-commit
         run: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -31,17 +31,17 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.13'
 
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
         with:
           terraform_version: '1.3.0'
 
       - name: Install tflint
-        uses: terraform-linters/setup-tflint@v4
+        uses: terraform-linters/setup-tflint@90f302c255ef959cbfb4bd10581afecdb7ece3e6 # v4
         with:
           tflint_version: v0.54.0
 
@@ -51,7 +51,7 @@ jobs:
           pip install pre-commit
 
       - name: Cache pre-commit hooks
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}-v3

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -75,7 +75,8 @@ jobs:
               echo "$CHANGED_FILES"
               pre-commit run --files $CHANGED_FILES
             else
-              echo "No Terraform files changed, skipping pre-commit checks"
+              echo "No Terraform files changed; running all hooks because workflow/config files changed"
+              pre-commit run --all-files
             fi
           fi
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,99 @@
+name: Pre-commit
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '**.tf'
+      - '**.tfvars'
+      - '.pre-commit-config.yaml'
+  push:
+    branches: [main]
+    paths:
+      - '**.tf'
+      - '**.tfvars'
+      - '.pre-commit-config.yaml'
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: '1.3.0'
+
+      - name: Install tflint
+        run: |
+          curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
+
+      - name: Install pre-commit
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+
+      - name: Cache pre-commit hooks
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}-v3
+
+      - name: Install pre-commit hooks
+        run: pre-commit install-hooks
+
+      # Skip terraform_docs in CI - rely on local pre-commit + AI review
+      # This eliminates environment parity issues between macOS and Linux
+      - name: Run pre-commit checks
+        env:
+          SKIP: terraform_docs
+        run: |
+          if [ "${{ github.event_name }}" == "push" ]; then
+            pre-commit run --all-files
+          else
+            git fetch origin ${{ github.base_ref }}
+            CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- '*.tf' '*.tfvars')
+            if [ -n "$CHANGED_FILES" ]; then
+              echo "Running pre-commit on changed files:"
+              echo "$CHANGED_FILES"
+              pre-commit run --files $CHANGED_FILES
+            else
+              echo "No Terraform files changed, skipping pre-commit checks"
+            fi
+          fi
+
+      - name: Pre-commit summary
+        if: always()
+        run: |
+          echo "## 🔍 Pre-commit Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [ "${{ job.status }}" == "success" ]; then
+            echo "✅ All pre-commit checks passed!" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**Checks performed:**" >> $GITHUB_STEP_SUMMARY
+            echo "- 🔧 Terraform formatting (terraform_fmt)" >> $GITHUB_STEP_SUMMARY
+            echo "- ✅ Terraform validation (terraform_validate)" >> $GITHUB_STEP_SUMMARY
+            echo "- 🔍 TFLint analysis (terraform_tflint)" >> $GITHUB_STEP_SUMMARY
+            echo "- 🧹 File formatting (trailing-whitespace, end-of-file)" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**Note:** Documentation (terraform_docs) is handled locally via pre-commit hooks." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "❌ Pre-commit checks failed" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Run \`pre-commit run --all-files\` locally to fix issues." >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,10 @@ repos:
       - id: check-added-large-files
         name: Check for large files
         args: ['--maxkb=1000']
+      - id: check-merge-conflict
+        name: Check for merge conflicts
+      - id: check-case-conflict
+        name: Check for case conflicts
 
   # Terraform-specific pre-commit hooks
   - repo: https://github.com/antonbabenko/pre-commit-terraform
@@ -36,7 +40,7 @@ repos:
         name: Terraform lint
         description: Validates all Terraform configuration files with TFLint
         args:
-          - --args=--only=terraform_deprecated_lookup
+          - --args=--config=__GIT_WORKING_DIR__/.tflint.hcl
 
   # Terraform documentation generation for the root module and examples
   - repo: local
@@ -53,12 +57,3 @@ repos:
           for d in examples/using_objects examples/using_variables examples/with_repository_policy examples/with_auth_token examples/with_ephemeral_auth_token examples/multiple_repositories; do
             terraform-docs --config .terraform-docs.yml "$d";
           done'
-
-  # Additional quality checks
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
-    hooks:
-      - id: check-merge-conflict
-        name: Check for merge conflicts
-      - id: check-case-conflict
-        name: Check for case conflicts

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,64 @@
+# Pre-commit configuration for terraform-aws-ecrpublic
+# https://pre-commit.com/hooks.html
+
+repos:
+  # Generic pre-commit hooks for file formatting
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+        name: Remove trailing whitespace
+      - id: end-of-file-fixer
+        name: Fix end of files
+      - id: check-yaml
+        name: Check YAML syntax
+      - id: check-added-large-files
+        name: Check for large files
+        args: ['--maxkb=1000']
+
+  # Terraform-specific pre-commit hooks
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.83.5
+    hooks:
+      - id: terraform_fmt
+        name: Terraform format
+        description: Rewrites all Terraform configuration files to a canonical format
+
+      - id: terraform_validate
+        name: Terraform validate
+        description: Validates all Terraform configuration files
+        # The ephemeral authorization token example intentionally requires Terraform >= 1.10.
+        # CI also runs this hook with Terraform 1.3 for root-module compatibility checks,
+        # so validate the ephemeral example separately with a newer Terraform version.
+        exclude: ^examples/with_ephemeral_auth_token/
+
+      - id: terraform_tflint
+        name: Terraform lint
+        description: Validates all Terraform configuration files with TFLint
+        args:
+          - --args=--only=terraform_deprecated_lookup
+
+  # Terraform documentation generation for the root module and examples
+  - repo: local
+    hooks:
+      - id: terraform_docs
+        name: Terraform docs
+        description: Updates Terraform docs in the root README and example READMEs
+        language: system
+        pass_filenames: false
+        files: \.tf$
+        entry: >-
+          bash -c 'set -euo pipefail;
+          terraform-docs --config .terraform-docs.yml .;
+          for d in examples/using_objects examples/using_variables examples/with_repository_policy examples/with_auth_token examples/with_ephemeral_auth_token examples/multiple_repositories; do
+            terraform-docs --config .terraform-docs.yml "$d";
+          done'
+
+  # Additional quality checks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: check-merge-conflict
+        name: Check for merge conflicts
+      - id: check-case-conflict
+        name: Check for case conflicts

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,0 +1,51 @@
+# TFLint configuration for terraform-aws-ecrpublic
+# https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/config.md
+
+config {
+  # Enable all rules by default
+  disabled_by_default = false
+
+  # Plugin cache directory
+  plugin_dir = "~/.tflint.d/plugins"
+}
+
+# AWS plugin for additional AWS-specific rules
+plugin "aws" {
+  enabled = true
+  version = "0.42.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}
+
+# Enable specific rules for deprecated syntax
+rule "terraform_deprecated_lookup" {
+  enabled = true
+}
+
+rule "terraform_unused_declarations" {
+  enabled = true
+}
+
+rule "terraform_comment_syntax" {
+  enabled = true
+}
+
+rule "terraform_documented_outputs" {
+  enabled = true
+}
+
+rule "terraform_documented_variables" {
+  enabled = true
+}
+
+rule "terraform_typed_variables" {
+  enabled = true
+}
+
+rule "terraform_module_pinned_source" {
+  enabled = true
+}
+
+rule "terraform_naming_convention" {
+  enabled = true
+  format  = "snake_case"
+}

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,51 +1,11 @@
 # TFLint configuration for terraform-aws-ecrpublic
-# https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/config.md
+# Keep this lightweight for pre-commit: catch deprecated lookup usage without
+# turning legacy naming/example conventions into required changes.
 
 config {
-  # Enable all rules by default
-  disabled_by_default = false
-
-  # Plugin cache directory
-  plugin_dir = "~/.tflint.d/plugins"
+  disabled_by_default = true
 }
 
-# AWS plugin for additional AWS-specific rules
-plugin "aws" {
-  enabled = true
-  version = "0.42.0"
-  source  = "github.com/terraform-linters/tflint-ruleset-aws"
-}
-
-# Enable specific rules for deprecated syntax
 rule "terraform_deprecated_lookup" {
   enabled = true
-}
-
-rule "terraform_unused_declarations" {
-  enabled = true
-}
-
-rule "terraform_comment_syntax" {
-  enabled = true
-}
-
-rule "terraform_documented_outputs" {
-  enabled = true
-}
-
-rule "terraform_documented_variables" {
-  enabled = true
-}
-
-rule "terraform_typed_variables" {
-  enabled = true
-}
-
-rule "terraform_module_pinned_source" {
-  enabled = true
-}
-
-rule "terraform_naming_convention" {
-  enabled = true
-  format  = "snake_case"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,10 +13,11 @@ ECR Public is a global public gallery service with API operations handled throug
 - `outputs.tf` - module outputs
 - `versions.tf` - Terraform and AWS provider constraints
 - `examples/` - registry-facing examples
+- `.github/workflows/pre-commit.yml` - lightweight Terraform formatting/validation/linting checks
 - `.github/workflows/release-please.yml` - semantic version/tag automation
 - `.github/workflows/claude*.yml` - AI/codebot automation
 
-This repo intentionally no longer contains repo-owned automated validation tooling or legacy test suites.
+This repo intentionally keeps pre-commit as the lightweight automated quality gate. It no longer contains the legacy Terratest suite or broader CI/security/test workflow stack.
 
 ## Development rules
 
@@ -32,8 +33,9 @@ This repo intentionally no longer contains repo-owned automated validation tooli
 
 ## Validation approach
 
-The maintainer preference for this repository is lightweight review instead of maintaining repo-owned automated validation tooling. Use:
+The maintainer preference for this repository is lightweight pre-commit plus review instead of maintaining the old Terratest/CI/security workflow stack. Use:
 
+- pre-commit for Terraform formatting, validation, linting, and generated docs
 - direct local Terraform commands for targeted checks when useful
 - AI/codebot review on pull requests
 - maintainer inspection and user reports for behavior validation
@@ -41,6 +43,7 @@ The maintainer preference for this repository is lightweight review instead of m
 Useful local commands when the touched files justify them:
 
 ```bash
+pre-commit run --all-files
 terraform fmt -check -recursive
 terraform init -backend=false -input=false
 terraform validate

--- a/README.md
+++ b/README.md
@@ -108,11 +108,12 @@ aws ecr-public get-login-password --region us-east-1 | docker login --username A
 
 ## Validation and maintenance
 
-This repository intentionally does not maintain repo-owned automated validation jobs or legacy test suites. Changes are reviewed through maintainer inspection, AI-assisted/codebot review, and user reports.
+This repository keeps lightweight pre-commit checks for Terraform formatting, validation, linting, and generated docs. It intentionally does not maintain the legacy Terratest suite or broader CI/security/test workflow stack. Changes are reviewed through pre-commit, maintainer inspection, AI-assisted/codebot review, and user reports.
 
 When validating changes locally, use the smallest direct Terraform commands that match the change. For example:
 
 ```bash
+pre-commit run --all-files
 terraform fmt -check -recursive
 terraform init -backend=false -input=false
 terraform validate


### PR DESCRIPTION
## Summary
- Restore the lightweight pre-commit workflow, hook configuration, and TFLint config
- Re-enable pre-commit in Claude/codebot allowed tools now that the config exists again
- Update README and CLAUDE.md to state that pre-commit is the retained quality gate while the legacy Terratest and broader CI/security/test workflow stack stay removed

## Validation
- `terraform init -backend=false -input=false`
- `terraform fmt -check -recursive`
- `terraform validate`
- `pre-commit run --all-files`

## Notes
This corrects the #79 cleanup scope: pre-commit should remain; the legacy Terratest suite and broader CI/security/test workflows remain removed.
