### PR TITLE
chore: use shared Renovate config for GitHub Actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,23 +1,37 @@
 {
-  "extends": ["config:base", "docker:enableMajor", ":enableVulnerabilityAlertsWithLabel(security)"],
-  "timezone": "America/New_York",
+  "extends": [
+    "github>lgallard/renovate-config",
+    "docker:enableMajor",
+    ":enableVulnerabilityAlertsWithLabel(security)"
+  ],
   "dependencyDashboard": true,
   "vulnerabilityAlerts": {
     "enabled": true
   },
   "terraform": {
-    "ignoreDeps": ["hashicorp/terraform"]
+    "ignoreDeps": [
+      "hashicorp/terraform"
+    ]
   },
   "packageRules": [
     {
-      "datasources": ["terraform-provider"],
-      "updateTypes": ["major"],
-      "enabled": false
+      "enabled": false,
+      "matchDatasources": [
+        "terraform-provider"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ]
     },
     {
       "groupName": "terraform providers",
-      "datasources": ["terraform-provider"],
-      "updateTypes": ["minor", "patch"]
+      "matchDatasources": [
+        "terraform-provider"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Extend the shared `github>lgallard/renovate-config` preset
- Keep existing repo-specific Renovate rules in place
- Ensure GitHub Actions workflow files are covered where the repo had restricted `includePaths`

## Why
This centralizes the recurring GitHub Actions update policy:
- weekly grouped GitHub Actions updates
- Anthropic/codebot actions separated for review
- major updates gated through the Dependency Dashboard
- Terraform provider/module updates remain non-automerge

## Validation
- `python3 -m json.tool renovate.json`
- `pnpm dlx --package renovate renovate-config-validator renovate.json`
